### PR TITLE
test-cli: write errors to stdout for test harness capture

### DIFF
--- a/src/sprites/exec.py
+++ b/src/sprites/exec.py
@@ -105,7 +105,7 @@ class Cmd:
         """
         code = self._run_sync()
         if code != 0:
-            raise ExitError(code, self._stdout_data, self._stderr_data)
+            raise ExitError(f"exit status {code}", code, self._stdout_data, self._stderr_data)
 
     def output(self) -> bytes:
         """Run command and return stdout (like exec.Cmd.Output).
@@ -125,7 +125,7 @@ class Cmd:
         code = self._run_sync()
 
         if code != 0:
-            raise ExitError(code, self._stdout_data, self._stderr_data)
+            raise ExitError(f"exit status {code}", code, self._stdout_data, self._stderr_data)
 
         return self._stdout_data
 
@@ -153,7 +153,7 @@ class Cmd:
         combined = self._stdout_data + self._stderr_data
 
         if code != 0:
-            raise ExitError(code, combined, b"")
+            raise ExitError(f"exit status {code}", code, combined, b"")
 
         return combined
 
@@ -265,6 +265,6 @@ def run(
     )
 
     if check and code != 0:
-        raise ExitError(code, result.stdout or b"", result.stderr or b"")
+        raise ExitError(f"exit status {code}", code, result.stdout or b"", result.stderr or b"")
 
     return result

--- a/src/sprites/websocket.py
+++ b/src/sprites/websocket.py
@@ -113,12 +113,15 @@ class WSCommand:
             max_size=10 * 1024 * 1024,  # 10MB max message size
         )
 
+        # Start I/O loop in background IMMEDIATELY after connect
+        # This must happen before any other awaits to avoid missing messages
+        self._io_task = asyncio.create_task(self._run_io())
+        # Yield to let the I/O task start reading before we return
+        await asyncio.sleep(0)
+
         # When attaching to an existing session, wait for session_info to determine TTY mode
         if self._is_attach:
             await self._wait_for_session_info()
-
-        # Start I/O loop in background
-        self._io_task = asyncio.create_task(self._run_io())
 
     async def _wait_for_session_info(self) -> None:
         """Wait for session_info message when attaching."""
@@ -152,24 +155,35 @@ class WSCommand:
         try:
             # Handle stdin in background if provided
             stdin_task: asyncio.Task[None] | None = None
+            eof_task: asyncio.Task[None] | None = None
             if self.cmd.stdin is not None:
                 stdin_task = asyncio.create_task(self._copy_stdin())
             else:
-                # Send EOF immediately if no stdin
-                await self._send_stdin_eof()
+                # Send EOF as a background task - don't block before reading
+                eof_task = asyncio.create_task(self._send_stdin_eof())
 
-            # Process incoming messages
+            # Process incoming messages - start reading immediately
+            # EOF task will run concurrently when we yield on message receive
             async for message in self.ws:
                 await self._handle_message(message)
 
         except ConnectionClosed as e:
-            # Non-normal closure - treat as error
-            # Note: websockets library doesn't raise for normal closure (1000),
-            # the async for loop just exits. We handle that in the else clause.
-            if self.exit_code < 0:
-                self.exit_code = 1
-        except Exception:
+            # Check if this is a normal closure (code 1000)
+            # The websockets library can sometimes raise ConnectionClosed even for normal closures
+            if e.code == 1000:
+                # Normal closure - treat as success if no exit code received
+                if self.exit_code < 0:
+                    self.exit_code = 0
+            else:
+                # Non-normal closure - treat as error
+                error_msg = f"WebSocket ConnectionClosed: code={e.code}, reason={e.reason}\n"
+                self._stderr_buffer.extend(error_msg.encode())
+                if self.exit_code < 0:
+                    self.exit_code = 1
+        except Exception as e:
             # Any other exception - treat as error
+            error_msg = f"WebSocket I/O error: {type(e).__name__}: {e}\n"
+            self._stderr_buffer.extend(error_msg.encode())
             if self.exit_code < 0:
                 self.exit_code = 1
         else:
@@ -178,11 +192,18 @@ class WSCommand:
                 self.exit_code = 0
         finally:
             self.done = True
+            # Clean up stdin task
             if stdin_task is not None:
                 stdin_task.cancel()
                 try:
                     await stdin_task
                 except asyncio.CancelledError:
+                    pass
+            # Ensure EOF task completed (don't cancel - it should finish quickly)
+            if eof_task is not None and not eof_task.done():
+                try:
+                    await eof_task
+                except Exception:
                     pass
 
     async def _handle_message(self, message: str | bytes) -> None:
@@ -222,6 +243,7 @@ class WSCommand:
                     self.cmd.stderr.write(payload)
             elif stream_id == StreamID.EXIT:
                 self.exit_code = payload[0] if payload else 0
+                # Close connection after receiving EXIT
                 if self.ws:
                     await self.ws.close()
 
@@ -271,7 +293,19 @@ class WSCommand:
     async def wait(self) -> int:
         """Wait for command to complete and return exit code."""
         if self._io_task is not None:
-            await self._io_task
+            try:
+                await self._io_task
+            except Exception as e:
+                # Task failed unexpectedly
+                error_msg = f"WebSocket task failed: {type(e).__name__}: {e}\n"
+                self._stderr_buffer.extend(error_msg.encode())
+                if self.exit_code < 0:
+                    self.exit_code = 1
+        # Safeguard: exit_code should never be -1 at this point
+        if self.exit_code < 0:
+            error_msg = "WebSocket error: exit code not set\n"
+            self._stderr_buffer.extend(error_msg.encode())
+            self.exit_code = 1
         return self.exit_code
 
     async def close(self) -> None:
@@ -304,8 +338,11 @@ async def run_ws_command(cmd: Cmd) -> int:
     try:
         await ws_cmd.start()
         exit_code = await ws_cmd.wait()
-    except Exception:
-        # If connection or I/O fails, return error exit code
+    except Exception as e:
+        # If connection or I/O fails, store error message in stderr buffer
+        # and return error exit code
+        error_msg = f"WebSocket error: {type(e).__name__}: {e}\n"
+        ws_cmd._stderr_buffer.extend(error_msg.encode())
         exit_code = 1
     finally:
         # Ensure connection is closed
@@ -315,6 +352,9 @@ async def run_ws_command(cmd: Cmd) -> int:
     if cmd._capture_stdout:
         cmd._stdout_data = ws_cmd.get_stdout()
     if cmd._capture_stderr:
+        cmd._stderr_data = ws_cmd.get_stderr()
+    # Always copy stderr on error for debugging, even if not explicitly capturing
+    elif exit_code != 0:
         cmd._stderr_data = ws_cmd.get_stderr()
 
     return exit_code

--- a/test_cli/main.py
+++ b/test_cli/main.py
@@ -618,12 +618,19 @@ def cmd_exec(
         if output_mode in ("stdout", "combined") and e.stdout:
             sys.stdout.buffer.write(e.stdout)
             sys.stdout.buffer.flush()
+        # Write error info to stdout for test harness capture
+        error_msg = f"ExitError: exit code {exit_code}"
+        if e.stderr:
+            error_msg += f", stderr: {e.stderr.decode('utf-8', errors='replace')}"
+        print(error_msg)
         sys.exit(exit_code)
     except SpriteTimeoutError as e:
-        print(f"Command timed out: {e}", file=sys.stderr)
+        # Write to stdout for test harness capture
+        print(f"Command timed out: {e}")
         sys.exit(1)
     except Exception as e:
-        print(f"Command failed: {e}", file=sys.stderr)
+        # Write to stdout for test harness capture
+        print(f"Command failed: {e}")
         sys.exit(1)
 
 


### PR DESCRIPTION
## Summary

Multiple improvements to error handling and WebSocket timing in the Python SDK.

### WebSocket Timing Fixes (src/sprites/websocket.py)
- **Fix I/O timing**: Start reader task immediately after connect (before any awaits)
- **Fix EOF timing**: Send stdin EOF concurrently to not block reading
- Proper cleanup of background tasks in finally block

### Error Handling Improvements
- Improved ConnectionClosed handling to distinguish normal (code 1000) vs abnormal closures
- Added error capture for WebSocket exceptions to help debugging  
- Added safeguard in wait() to ensure exit code is always set
- Always copy stderr on error for debugging even if not explicitly capturing

### test_cli/main.py
- Error handlers now write to stdout so the test harness can capture actual error messages

## Root Cause

The concurrent commands test was failing because Python's asyncio model had a race condition:
1. WebSocket connected
2. stdin EOF was sent (with an await)
3. THEN the reader task started

This meant early server output could be missed. The fix starts the I/O reader immediately after connect and sends EOF concurrently.

## Test Plan

- [x] Error messages now captured by test harness
- [x] ExitError properly includes stderr when available
- [x] TestConcurrentCommands passes
- [x] All Python SDK tests pass

Fixes #5