### PR TITLE
Fix EXIT handling - break loop instead of closing mid-iteration

### DIFF
--- a/src/sprites/websocket.py
+++ b/src/sprites/websocket.py
@@ -166,6 +166,9 @@ class WSCommand:
             # EOF task will run concurrently when we yield on message receive
             async for message in self.ws:
                 await self._handle_message(message)
+                # Exit loop when EXIT message received
+                if self.done:
+                    break
 
         except ConnectionClosed as e:
             # Check if this is a normal closure (code 1000)
@@ -243,9 +246,8 @@ class WSCommand:
                     self.cmd.stderr.write(payload)
             elif stream_id == StreamID.EXIT:
                 self.exit_code = payload[0] if payload else 0
-                # Close connection after receiving EXIT
-                if self.ws:
-                    await self.ws.close()
+                # Mark as done - the connection will close and loop will exit
+                self.done = True
 
     async def _copy_stdin(self) -> None:
         """Copy data from stdin to WebSocket."""


### PR DESCRIPTION
## Problem

When receiving an EXIT message, the code was calling `ws.close()` while still inside the `async for` message loop. This could cause race conditions where:
1. EXIT received, exit_code set
2. ws.close() called
3. Loop continues/errors before close completes
4. exit_code gets reset or lost

This caused intermittent `exit status 255` errors (255 = -1 as unsigned byte).

## Fix

Instead of closing the WebSocket mid-iteration:
1. Set `self.done = True` when EXIT is received
2. Check `self.done` after each message and `break` from the loop
3. The loop exits normally, `else` clause runs, exit_code is preserved

This matches the Go SDK pattern which returns immediately after EXIT.