### PR TITLE
Add structured APIError with upgrade_url field

### DIFF
--- a/src/sprites/exceptions.py
+++ b/src/sprites/exceptions.py
@@ -2,7 +2,8 @@
 Exceptions for the Sprites SDK
 """
 
-from typing import Optional
+import json
+from typing import Any, Optional
 
 
 class SpriteError(Exception):
@@ -25,18 +26,171 @@ class NotFoundError(SpriteError):
     pass
 
 
+# Error codes returned by the API for rate limiting
+ERR_CODE_CREATION_RATE_LIMITED = "sprite_creation_rate_limited"
+ERR_CODE_CONCURRENT_LIMIT_EXCEEDED = "concurrent_sprite_limit_exceeded"
+
+
 class APIError(SpriteError):
-    """API request failed."""
+    """Structured error response from the Sprites API.
+
+    Provides detailed information about rate limits and other API errors.
+    """
 
     def __init__(
         self,
         message: str,
         status_code: Optional[int] = None,
-        response: Optional[str] = None
+        response: Optional[str] = None,
+        *,
+        error_code: Optional[str] = None,
+        limit: Optional[int] = None,
+        window_seconds: Optional[int] = None,
+        retry_after_seconds: Optional[int] = None,
+        current_count: Optional[int] = None,
+        upgrade_available: bool = False,
+        upgrade_url: Optional[str] = None,
+        retry_after_header: Optional[int] = None,
+        rate_limit_limit: Optional[int] = None,
+        rate_limit_remaining: Optional[int] = None,
+        rate_limit_reset: Optional[int] = None,
     ):
         super().__init__(message)
         self.status_code = status_code
         self.response = response
+        # Structured fields from JSON body
+        self.error_code = error_code
+        self.limit = limit
+        self.window_seconds = window_seconds
+        self.retry_after_seconds = retry_after_seconds
+        self.current_count = current_count
+        self.upgrade_available = upgrade_available
+        self.upgrade_url = upgrade_url
+        # Fields from HTTP headers
+        self.retry_after_header = retry_after_header
+        self.rate_limit_limit = rate_limit_limit
+        self.rate_limit_remaining = rate_limit_remaining
+        self.rate_limit_reset = rate_limit_reset
+
+    def is_rate_limit_error(self) -> bool:
+        """Returns True if this is a 429 rate limit error."""
+        return self.status_code == 429
+
+    def is_creation_rate_limited(self) -> bool:
+        """Returns True if this is a sprite creation rate limit error."""
+        return self.error_code == ERR_CODE_CREATION_RATE_LIMITED
+
+    def is_concurrent_limit_exceeded(self) -> bool:
+        """Returns True if this is a concurrent sprite limit error."""
+        return self.error_code == ERR_CODE_CONCURRENT_LIMIT_EXCEEDED
+
+    def get_retry_after_seconds(self) -> Optional[int]:
+        """Returns the number of seconds to wait before retrying.
+
+        Prefers the JSON field, falling back to the header value.
+        """
+        if self.retry_after_seconds is not None and self.retry_after_seconds > 0:
+            return self.retry_after_seconds
+        return self.retry_after_header
+
+
+def parse_api_error(
+    status_code: int,
+    body: bytes,
+    headers: Optional[dict[str, str]] = None,
+) -> Optional[APIError]:
+    """Parse a structured API error from an HTTP response.
+
+    Args:
+        status_code: The HTTP status code.
+        body: The response body as bytes.
+        headers: Optional HTTP headers dict.
+
+    Returns:
+        An APIError if status_code >= 400, None otherwise.
+    """
+    if status_code < 400:
+        return None
+
+    headers = headers or {}
+
+    # Parse rate limit headers
+    retry_after_header: Optional[int] = None
+    rate_limit_limit: Optional[int] = None
+    rate_limit_remaining: Optional[int] = None
+    rate_limit_reset: Optional[int] = None
+
+    if ra := headers.get("retry-after") or headers.get("Retry-After"):
+        try:
+            retry_after_header = int(ra)
+        except ValueError:
+            pass
+
+    if rl := headers.get("x-ratelimit-limit") or headers.get("X-RateLimit-Limit"):
+        try:
+            rate_limit_limit = int(rl)
+        except ValueError:
+            pass
+
+    if rr := headers.get("x-ratelimit-remaining") or headers.get("X-RateLimit-Remaining"):
+        try:
+            rate_limit_remaining = int(rr)
+        except ValueError:
+            pass
+
+    if rs := headers.get("x-ratelimit-reset") or headers.get("X-RateLimit-Reset"):
+        try:
+            rate_limit_reset = int(rs)
+        except ValueError:
+            pass
+
+    # Try to parse JSON body
+    message = ""
+    error_code: Optional[str] = None
+    limit: Optional[int] = None
+    window_seconds: Optional[int] = None
+    retry_after_seconds: Optional[int] = None
+    current_count: Optional[int] = None
+    upgrade_available = False
+    upgrade_url: Optional[str] = None
+
+    body_str = body.decode("utf-8", errors="replace") if body else ""
+
+    if body:
+        try:
+            data: dict[str, Any] = json.loads(body)
+            error_code = data.get("error")
+            message = data.get("message", "")
+            limit = data.get("limit")
+            window_seconds = data.get("window_seconds")
+            retry_after_seconds = data.get("retry_after_seconds")
+            current_count = data.get("current_count")
+            upgrade_available = data.get("upgrade_available", False)
+            upgrade_url = data.get("upgrade_url")
+        except json.JSONDecodeError:
+            # Use raw body as message
+            message = body_str
+
+    # Fallback message if nothing was parsed
+    if not message and not error_code:
+        message = f"API error (status {status_code})"
+
+    return APIError(
+        message=message or error_code or f"API error (status {status_code})",
+        status_code=status_code,
+        response=body_str,
+        error_code=error_code,
+        limit=limit,
+        window_seconds=window_seconds,
+        retry_after_seconds=retry_after_seconds,
+        current_count=current_count,
+        upgrade_available=upgrade_available,
+        upgrade_url=upgrade_url,
+        retry_after_header=retry_after_header,
+        rate_limit_limit=rate_limit_limit,
+        rate_limit_remaining=rate_limit_remaining,
+        rate_limit_reset=rate_limit_reset,
+    )
 
 
 class ExecError(SpriteError):

--- a/src/sprites/websocket.py
+++ b/src/sprites/websocket.py
@@ -9,7 +9,9 @@ from typing import TYPE_CHECKING, Any, Callable
 from urllib.parse import urlencode
 
 import websockets
-from websockets.exceptions import ConnectionClosed
+from websockets.exceptions import ConnectionClosed, InvalidStatusCode
+
+from sprites.exceptions import parse_api_error
 
 if TYPE_CHECKING:
     from sprites.exec import Cmd
@@ -105,13 +107,29 @@ class WSCommand:
         url = self._build_websocket_url()
         headers = {"Authorization": f"Bearer {self.cmd.sprite.client.token}"}
 
-        self.ws = await websockets.connect(
-            url,
-            additional_headers=headers,
-            ping_interval=WS_PING_INTERVAL,
-            ping_timeout=WS_PONG_WAIT,
-            max_size=10 * 1024 * 1024,  # 10MB max message size
-        )
+        try:
+            self.ws = await websockets.connect(
+                url,
+                additional_headers=headers,
+                ping_interval=WS_PING_INTERVAL,
+                ping_timeout=WS_PONG_WAIT,
+                max_size=10 * 1024 * 1024,  # 10MB max message size
+            )
+        except InvalidStatusCode as e:
+            # Try to parse as a structured API error
+            body = b""
+            response_headers: dict[str, str] = {}
+            if hasattr(e, "response") and e.response is not None:
+                # websockets >= 12.0 provides response object
+                if hasattr(e.response, "body"):
+                    body = e.response.body or b""
+                if hasattr(e.response, "headers"):
+                    response_headers = dict(e.response.headers)
+            api_err = parse_api_error(e.status_code, body, response_headers)
+            if api_err is not None:
+                raise api_err from None
+            # Fall back to original exception
+            raise
 
         # Start I/O loop in background IMMEDIATELY after connect
         # This must happen before any other awaits to avoid missing messages

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,232 @@
+"""Tests for the Sprites SDK exceptions module."""
+
+import json
+import pytest
+
+from sprites.exceptions import (
+    APIError,
+    parse_api_error,
+    ERR_CODE_CREATION_RATE_LIMITED,
+    ERR_CODE_CONCURRENT_LIMIT_EXCEEDED,
+)
+
+
+class TestAPIError:
+    """Tests for the APIError class."""
+
+    def test_basic_error(self):
+        """Test creating a basic APIError."""
+        err = APIError("Something went wrong", status_code=500)
+        assert str(err) == "Something went wrong"
+        assert err.status_code == 500
+        assert err.error_code is None
+
+    def test_error_with_all_fields(self):
+        """Test creating an APIError with all fields populated."""
+        err = APIError(
+            "Rate limit exceeded",
+            status_code=429,
+            response='{"error": "rate_limited"}',
+            error_code="sprite_creation_rate_limited",
+            limit=10,
+            window_seconds=60,
+            retry_after_seconds=30,
+            current_count=5,
+            upgrade_available=True,
+            upgrade_url="https://fly.io/upgrade",
+            retry_after_header=25,
+            rate_limit_limit=100,
+            rate_limit_remaining=0,
+            rate_limit_reset=1706400000,
+        )
+        assert err.status_code == 429
+        assert err.error_code == "sprite_creation_rate_limited"
+        assert err.limit == 10
+        assert err.window_seconds == 60
+        assert err.retry_after_seconds == 30
+        assert err.current_count == 5
+        assert err.upgrade_available is True
+        assert err.upgrade_url == "https://fly.io/upgrade"
+        assert err.retry_after_header == 25
+        assert err.rate_limit_limit == 100
+        assert err.rate_limit_remaining == 0
+        assert err.rate_limit_reset == 1706400000
+
+    def test_is_rate_limit_error(self):
+        """Test is_rate_limit_error method."""
+        err_429 = APIError("Rate limited", status_code=429)
+        err_500 = APIError("Server error", status_code=500)
+        err_none = APIError("Unknown error")
+
+        assert err_429.is_rate_limit_error() is True
+        assert err_500.is_rate_limit_error() is False
+        assert err_none.is_rate_limit_error() is False
+
+    def test_is_creation_rate_limited(self):
+        """Test is_creation_rate_limited method."""
+        err_creation = APIError(
+            "Rate limited",
+            status_code=429,
+            error_code=ERR_CODE_CREATION_RATE_LIMITED,
+        )
+        err_concurrent = APIError(
+            "Limit exceeded",
+            status_code=429,
+            error_code=ERR_CODE_CONCURRENT_LIMIT_EXCEEDED,
+        )
+        err_other = APIError("Other error", status_code=429, error_code="other_error")
+
+        assert err_creation.is_creation_rate_limited() is True
+        assert err_concurrent.is_creation_rate_limited() is False
+        assert err_other.is_creation_rate_limited() is False
+
+    def test_is_concurrent_limit_exceeded(self):
+        """Test is_concurrent_limit_exceeded method."""
+        err_concurrent = APIError(
+            "Limit exceeded",
+            status_code=429,
+            error_code=ERR_CODE_CONCURRENT_LIMIT_EXCEEDED,
+        )
+        err_creation = APIError(
+            "Rate limited",
+            status_code=429,
+            error_code=ERR_CODE_CREATION_RATE_LIMITED,
+        )
+
+        assert err_concurrent.is_concurrent_limit_exceeded() is True
+        assert err_creation.is_concurrent_limit_exceeded() is False
+
+    def test_get_retry_after_seconds_prefers_json(self):
+        """Test that get_retry_after_seconds prefers JSON field over header."""
+        err = APIError(
+            "Rate limited",
+            status_code=429,
+            retry_after_seconds=30,
+            retry_after_header=60,
+        )
+        assert err.get_retry_after_seconds() == 30
+
+    def test_get_retry_after_seconds_falls_back_to_header(self):
+        """Test that get_retry_after_seconds falls back to header when JSON is not set."""
+        err = APIError(
+            "Rate limited",
+            status_code=429,
+            retry_after_header=60,
+        )
+        assert err.get_retry_after_seconds() == 60
+
+    def test_get_retry_after_seconds_returns_none(self):
+        """Test that get_retry_after_seconds returns None when neither is set."""
+        err = APIError("Rate limited", status_code=429)
+        assert err.get_retry_after_seconds() is None
+
+
+class TestParseAPIError:
+    """Tests for the parse_api_error function."""
+
+    def test_returns_none_for_success_status(self):
+        """Test that parse_api_error returns None for status < 400."""
+        assert parse_api_error(200, b"OK") is None
+        assert parse_api_error(201, b"Created") is None
+        assert parse_api_error(204, b"") is None
+        assert parse_api_error(301, b"Moved") is None
+        assert parse_api_error(399, b"Something") is None
+
+    def test_parses_json_body(self):
+        """Test parsing a JSON error response body."""
+        body = json.dumps({
+            "error": "sprite_creation_rate_limited",
+            "message": "Rate limit exceeded",
+            "limit": 10,
+            "window_seconds": 60,
+            "retry_after_seconds": 30,
+            "upgrade_available": True,
+            "upgrade_url": "https://fly.io/upgrade",
+        }).encode()
+
+        err = parse_api_error(429, body)
+        assert err is not None
+        assert err.status_code == 429
+        assert err.error_code == "sprite_creation_rate_limited"
+        assert str(err) == "Rate limit exceeded"
+        assert err.limit == 10
+        assert err.window_seconds == 60
+        assert err.retry_after_seconds == 30
+        assert err.upgrade_available is True
+        assert err.upgrade_url == "https://fly.io/upgrade"
+
+    def test_parses_rate_limit_headers(self):
+        """Test parsing rate limit headers."""
+        headers = {
+            "Retry-After": "30",
+            "X-RateLimit-Limit": "100",
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "1706400000",
+        }
+        body = b'{"error": "rate_limited", "message": "Too many requests"}'
+
+        err = parse_api_error(429, body, headers)
+        assert err is not None
+        assert err.retry_after_header == 30
+        assert err.rate_limit_limit == 100
+        assert err.rate_limit_remaining == 0
+        assert err.rate_limit_reset == 1706400000
+
+    def test_parses_lowercase_headers(self):
+        """Test parsing lowercase headers (as some HTTP libraries normalize them)."""
+        headers = {
+            "retry-after": "30",
+            "x-ratelimit-limit": "100",
+        }
+        body = b'{"message": "Rate limited"}'
+
+        err = parse_api_error(429, body, headers)
+        assert err is not None
+        assert err.retry_after_header == 30
+        assert err.rate_limit_limit == 100
+
+    def test_handles_non_json_body(self):
+        """Test that non-JSON bodies are used as the message."""
+        body = b"Internal Server Error: something went wrong"
+
+        err = parse_api_error(500, body)
+        assert err is not None
+        assert err.status_code == 500
+        assert str(err) == "Internal Server Error: something went wrong"
+        assert err.error_code is None
+
+    def test_handles_empty_body(self):
+        """Test handling empty response body."""
+        err = parse_api_error(500, b"")
+        assert err is not None
+        assert err.status_code == 500
+        assert "API error (status 500)" in str(err)
+
+    def test_handles_invalid_header_values(self):
+        """Test that invalid header values don't cause errors."""
+        headers = {
+            "Retry-After": "not-a-number",
+            "X-RateLimit-Limit": "invalid",
+        }
+        body = b'{"message": "Error"}'
+
+        err = parse_api_error(429, body, headers)
+        assert err is not None
+        assert err.retry_after_header is None
+        assert err.rate_limit_limit is None
+
+    def test_concurrent_limit_error(self):
+        """Test parsing a concurrent limit error response."""
+        body = json.dumps({
+            "error": "concurrent_sprite_limit_exceeded",
+            "message": "Too many concurrent sprites",
+            "current_count": 5,
+            "limit": 5,
+        }).encode()
+
+        err = parse_api_error(429, body)
+        assert err is not None
+        assert err.error_code == ERR_CODE_CONCURRENT_LIMIT_EXCEEDED
+        assert err.current_count == 5
+        assert err.limit == 5
+        assert err.is_concurrent_limit_exceeded() is True


### PR DESCRIPTION
## Summary

- Add `upgrade_url` and other structured fields to `APIError` class
- Add `parse_api_error()` helper function for parsing HTTP error responses
- Update `websocket.py` to parse HTTP errors as structured `APIError` on dial failures
- Add comprehensive tests for `APIError` and `parse_api_error`

This matches the error handling improvements in the Go SDK, allowing callers to access structured error information (error code, limits, upgrade URL) directly from rate limit and other API errors.