### PR TITLE
Fix control mode: default to off and add fallback

### DIFF
--- a/src/sprites/__init__.py
+++ b/src/sprites/__init__.py
@@ -23,6 +23,7 @@ Usage:
 from .client import SpritesClient
 from .sprite import Sprite
 from .filesystem import SpriteFilesystem, SpritePath
+from .control import ControlConnection, OpConn
 from .exceptions import (
     SpriteError,
     NetworkError,
@@ -69,6 +70,8 @@ __all__ = [
     "Sprite",
     "SpriteFilesystem",
     "SpritePath",
+    "ControlConnection",
+    "OpConn",
     # Exceptions
     "SpriteError",
     "NetworkError",

--- a/src/sprites/client.py
+++ b/src/sprites/client.py
@@ -28,7 +28,8 @@ class SpritesClient:
         self,
         token: str,
         base_url: str = "https://api.sprites.dev",
-        timeout: float = 30.0
+        timeout: float = 30.0,
+        control_mode: bool = False,
     ):
         """
         Initialize the Sprites client.
@@ -37,10 +38,12 @@ class SpritesClient:
             token: Authentication token
             base_url: Base URL for the API (default: https://api.sprites.dev)
             timeout: HTTP request timeout in seconds (default: 30.0)
+            control_mode: Enable control mode for multiplexed WebSocket operations (default: False)
         """
         self.token = token
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
+        self.control_mode = control_mode
         self._client = httpx.Client(timeout=timeout)
 
     def __enter__(self) -> "SpritesClient":

--- a/src/sprites/control.py
+++ b/src/sprites/control.py
@@ -1,0 +1,662 @@
+"""Control connection for multiplexed operations over a single WebSocket."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING, Any, Dict, Optional, Callable
+from urllib.parse import urlencode
+
+import websockets
+from websockets.exceptions import ConnectionClosed
+
+if TYPE_CHECKING:
+    from .sprite import Sprite
+
+# Control envelope protocol constants (must match server's pkg/wss)
+CONTROL_PREFIX = "control:"
+TYPE_OP_START = "op.start"
+TYPE_OP_COMPLETE = "op.complete"
+TYPE_OP_ERROR = "op.error"
+
+# WebSocket keepalive timeouts
+WS_PING_INTERVAL = 15  # seconds
+WS_PONG_WAIT = 45  # seconds
+
+
+class StreamID:
+    """Stream identifiers for the binary protocol."""
+    STDIN = 0
+    STDOUT = 1
+    STDERR = 2
+    EXIT = 3
+    STDIN_EOF = 4
+
+
+class OpConn:
+    """Represents an active operation on a control connection."""
+
+    def __init__(self, cc: ControlConnection, tty: bool = False):
+        """Initialize an operation connection.
+
+        Args:
+            cc: Parent control connection
+            tty: Whether TTY mode is enabled
+        """
+        self.cc = cc
+        self.tty = tty
+        self.closed = False
+        self.exit_code = -1
+        self._done_event = asyncio.Event()
+
+        # Output buffers
+        self._stdout_buffer: bytearray = bytearray()
+        self._stderr_buffer: bytearray = bytearray()
+
+        # Callbacks
+        self.on_stdout: Optional[Callable[[bytes], None]] = None
+        self.on_stderr: Optional[Callable[[bytes], None]] = None
+        self.on_message: Optional[Callable[[dict], None]] = None
+
+    async def write(self, data: bytes) -> None:
+        """Write data to the operation (stdin).
+
+        Args:
+            data: Data to write
+        """
+        if self.closed:
+            raise RuntimeError("Operation closed")
+
+        if self.tty:
+            # PTY mode - send raw data
+            await self.cc._send_data(data)
+        else:
+            # Non-PTY mode - prepend stream ID
+            message = bytes([StreamID.STDIN]) + data
+            await self.cc._send_data(message)
+
+    async def send_eof(self) -> None:
+        """Send stdin EOF."""
+        if self.closed or self.tty:
+            return
+        await self.cc._send_data(bytes([StreamID.STDIN_EOF]))
+
+    async def resize(self, cols: int, rows: int) -> None:
+        """Send resize control message (TTY only).
+
+        Args:
+            cols: Number of columns
+            rows: Number of rows
+        """
+        if not self.tty:
+            return
+        msg = json.dumps({"type": "resize", "cols": cols, "rows": rows})
+        await self.cc._send_text(msg)
+
+    async def signal(self, sig: str) -> None:
+        """Send signal to remote process.
+
+        Args:
+            sig: Signal name (e.g., "TERM", "INT")
+        """
+        msg = json.dumps({"type": "signal", "signal": sig})
+        await self.cc._send_text(msg)
+
+    def handle_data(self, data: bytes) -> None:
+        """Handle incoming data frame.
+
+        Args:
+            data: Incoming data
+        """
+        if self.tty:
+            # PTY mode - emit raw output
+            self._stdout_buffer.extend(data)
+            if self.on_stdout:
+                self.on_stdout(data)
+        else:
+            # Non-PTY mode - parse stream prefix
+            if not data:
+                return
+
+            stream_id = data[0]
+            payload = data[1:]
+
+            if stream_id == StreamID.STDOUT:
+                self._stdout_buffer.extend(payload)
+                if self.on_stdout:
+                    self.on_stdout(payload)
+            elif stream_id == StreamID.STDERR:
+                self._stderr_buffer.extend(payload)
+                if self.on_stderr:
+                    self.on_stderr(payload)
+            elif stream_id == StreamID.EXIT:
+                # Store exit code but DON'T signal done yet
+                # Wait for op.complete message to ensure proper sequencing
+                self.exit_code = payload[0] if payload else 0
+
+    def handle_text(self, data: str) -> None:
+        """Handle text message (session_info, notifications, etc.).
+
+        Args:
+            data: Text message data
+        """
+        try:
+            msg = json.loads(data)
+            if self.on_message:
+                self.on_message(msg)
+        except json.JSONDecodeError:
+            pass
+
+    def complete(self, exit_code: Optional[int] = None) -> None:
+        """Mark operation as complete.
+
+        Args:
+            exit_code: Optional exit code
+        """
+        if self.closed:
+            return
+        self.closed = True
+        if exit_code is not None:
+            self.exit_code = exit_code
+        self._done_event.set()
+
+    def close(self) -> None:
+        """Close the operation."""
+        if self.closed:
+            return
+        self.closed = True
+        self._done_event.set()
+
+    def is_closed(self) -> bool:
+        """Check if operation is closed."""
+        return self.closed
+
+    def get_exit_code(self) -> int:
+        """Get exit code (-1 if not exited)."""
+        return self.exit_code
+
+    async def wait(self) -> int:
+        """Wait for operation to complete.
+
+        Returns:
+            Exit code
+        """
+        if self.closed:
+            return self.exit_code
+        await self._done_event.wait()
+        return self.exit_code
+
+    def get_stdout(self) -> bytes:
+        """Get accumulated stdout buffer."""
+        return bytes(self._stdout_buffer)
+
+    def get_stderr(self) -> bytes:
+        """Get accumulated stderr buffer."""
+        return bytes(self._stderr_buffer)
+
+
+class ControlConnection:
+    """Manages a persistent WebSocket connection for multiplexed operations."""
+
+    def __init__(self, sprite: Sprite):
+        """Initialize a control connection.
+
+        Args:
+            sprite: The sprite this connection is for
+        """
+        self.sprite = sprite
+        self.ws: websockets.WebSocketClientProtocol | None = None
+        self.op_active = False
+        self.op_conn: OpConn | None = None
+        self.closed = False
+        self.close_error: Optional[Exception] = None
+        self._read_task: Optional[asyncio.Task[None]] = None
+
+    async def connect(self) -> None:
+        """Connect to the control endpoint."""
+        if self.ws is not None:
+            raise RuntimeError("Already connected")
+
+        # Build WebSocket URL
+        base_url = self.sprite.client.base_url
+        if base_url.startswith("https"):
+            base_url = "wss" + base_url[5:]
+        elif base_url.startswith("http"):
+            base_url = "ws" + base_url[4:]
+
+        url = f"{base_url}/v1/sprites/{self.sprite.name}/control"
+        headers = {"Authorization": f"Bearer {self.sprite.client.token}"}
+
+        self.ws = await websockets.connect(
+            url,
+            additional_headers=headers,
+            ping_interval=WS_PING_INTERVAL,
+            ping_timeout=WS_PONG_WAIT,
+            close_timeout=2,  # Faster close handshake for clean shutdown
+            max_size=10 * 1024 * 1024,  # 10MB
+        )
+
+        # Start read loop
+        self._read_task = asyncio.create_task(self._read_loop())
+
+    async def _read_loop(self) -> None:
+        """Read messages from WebSocket."""
+        if self.ws is None:
+            return
+
+        try:
+            async for message in self.ws:
+                await self._handle_message(message)
+        except ConnectionClosed as e:
+            self.close_error = e
+        except Exception as e:
+            self.close_error = e
+        finally:
+            self.closed = True
+            if self.op_conn is not None:
+                self.op_conn.close()
+
+    async def _handle_message(self, message: str | bytes) -> None:
+        """Handle incoming WebSocket message.
+
+        Args:
+            message: Incoming message
+        """
+        # Check for control message
+        if isinstance(message, str) and message.startswith(CONTROL_PREFIX):
+            payload = message[len(CONTROL_PREFIX):]
+            try:
+                msg = json.loads(payload)
+                self._handle_control_message(msg)
+            except json.JSONDecodeError:
+                pass
+            return
+
+        # Data frame - deliver to active operation
+        if self.op_conn is not None:
+            if isinstance(message, str):
+                self.op_conn.handle_text(message)
+            else:
+                self.op_conn.handle_data(message)
+
+    def _handle_control_message(self, msg: Dict[str, Any]) -> None:
+        """Handle control envelope message.
+
+        Args:
+            msg: Parsed control message
+        """
+        msg_type = msg.get("type", "")
+
+        if msg_type == TYPE_OP_COMPLETE:
+            if self.op_conn is not None:
+                exit_code = msg.get("args", {}).get("exitCode", 0)
+                self.op_conn.complete(exit_code)
+            self.op_active = False
+            self.op_conn = None
+
+        elif msg_type == TYPE_OP_ERROR:
+            if self.op_conn is not None:
+                error = msg.get("args", {}).get("error", "unknown error")
+                # Store error in stderr buffer
+                self.op_conn._stderr_buffer.extend(f"Error: {error}\n".encode())
+                self.op_conn.complete()
+            self.op_active = False
+            self.op_conn = None
+
+    async def start_op(
+        self,
+        op: str,
+        cmd: Optional[list[str]] = None,
+        env: Optional[Dict[str, str]] = None,
+        dir: Optional[str] = None,
+        tty: bool = False,
+        rows: int = 24,
+        cols: int = 80,
+        stdin: bool = True,
+    ) -> OpConn:
+        """Start a new operation.
+
+        Args:
+            op: Operation name (e.g., "exec")
+            cmd: Command and arguments
+            env: Environment variables
+            dir: Working directory
+            tty: Enable TTY mode
+            rows: TTY rows
+            cols: TTY columns
+            stdin: Whether stdin is expected
+
+        Returns:
+            OpConn for the operation
+        """
+        if self.closed:
+            raise RuntimeError(f"Control connection closed: {self.close_error}")
+
+        # Note: op_active is now managed by the pool, so we don't check it here
+        # The pool ensures only one caller has this connection at a time
+
+        if self.ws is None:
+            raise RuntimeError("WebSocket not connected")
+        op_conn = OpConn(self, tty)
+        self.op_conn = op_conn
+
+        # Build args for the control message
+        args: Dict[str, Any] = {}
+        if cmd:
+            args["cmd"] = cmd
+        if env:
+            env_list = [f"{k}={v}" for k, v in env.items()]
+            args["env"] = env_list
+        if dir:
+            args["dir"] = dir
+        if tty:
+            args["tty"] = "true"
+            args["rows"] = str(rows)
+            args["cols"] = str(cols)
+        args["stdin"] = "true" if stdin else "false"
+
+        # Send op.start
+        ctrl_msg = {
+            "type": TYPE_OP_START,
+            "op": op,
+            "args": args,
+        }
+        frame = CONTROL_PREFIX + json.dumps(ctrl_msg)
+        await self.ws.send(frame)
+
+        return op_conn
+
+    async def _send_data(self, data: bytes) -> None:
+        """Send data frame.
+
+        Args:
+            data: Data to send
+        """
+        if self.ws is None or self.ws.state != websockets.protocol.State.OPEN:
+            raise RuntimeError("WebSocket not connected")
+        await self.ws.send(data)
+
+    async def _send_text(self, data: str) -> None:
+        """Send text frame.
+
+        Args:
+            data: Text to send
+        """
+        if self.ws is None or self.ws.state != websockets.protocol.State.OPEN:
+            raise RuntimeError("WebSocket not connected")
+        await self.ws.send(data)
+
+    async def close(self) -> None:
+        """Close the control connection.
+
+        Proper close sequence per websockets library documentation:
+        1. Close the websocket (causes read loop to exit via ConnectionClosed)
+        2. Wait for the close to complete with wait_closed()
+        3. Wait for read task to finish naturally
+        """
+        if self.op_conn is not None:
+            self.op_conn.close()
+
+        # Close websocket first - this will cause the read loop to exit
+        # with ConnectionClosed exception, allowing proper cleanup
+        ws = self.ws
+        if ws is not None:
+            try:
+                await ws.close()
+                # wait_closed() ensures all internal tasks (like keepalive) are done
+                await ws.wait_closed()
+            except Exception:
+                pass
+
+        # Now wait for read task to finish naturally (it will exit due to close)
+        if self._read_task is not None:
+            try:
+                # Wait with timeout in case read task is stuck
+                await asyncio.wait_for(self._read_task, timeout=2.0)
+            except asyncio.TimeoutError:
+                # If it doesn't finish, cancel as fallback
+                self._read_task.cancel()
+                try:
+                    await self._read_task
+                except asyncio.CancelledError:
+                    pass
+            except Exception:
+                pass
+            self._read_task = None
+
+        self.ws = None
+        self.closed = True
+
+    def is_closed(self) -> bool:
+        """Check if connection is closed."""
+        return self.closed
+
+
+# Pool configuration (matches Go SDK)
+MAX_POOL_SIZE = 100  # Sanity cap - checkout fails if pool is full
+POOL_DRAIN_THRESHOLD = 20  # When release and size > this, drain idle conns
+POOL_DRAIN_TARGET = 10  # Drain down to this many conns when draining
+
+
+class ControlPool:
+    """Manages a pool of control connections for concurrent operations."""
+
+    def __init__(self, sprite: Sprite, max_size: int = MAX_POOL_SIZE):
+        """Initialize a control pool.
+
+        Args:
+            sprite: The sprite to connect to
+            max_size: Maximum number of connections in the pool (default 100)
+        """
+        self.sprite = sprite
+        self.max_size = max_size
+        self.conns: list[ControlConnection] = []
+        self.waiters: list[asyncio.Future[ControlConnection]] = []
+        self.closed = False
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> ControlConnection:
+        """Acquire a connection from the pool.
+
+        Creates a new connection if the pool isn't full, otherwise waits.
+
+        Returns:
+            ControlConnection that is ready for use
+        """
+        async with self._lock:
+            if self.closed:
+                raise RuntimeError("Pool is closed")
+
+            # Try to find an available connection
+            for cc in self.conns:
+                if not cc.is_closed() and not cc.op_active:
+                    cc.op_active = True  # Mark as in use
+                    return cc
+
+            # If pool isn't full, create a new connection
+            if len(self.conns) < self.max_size:
+                cc = ControlConnection(self.sprite)
+                await cc.connect()
+                self.conns.append(cc)
+                cc.op_active = True  # Mark as in use
+                return cc
+
+            # Pool is full, wait for a connection
+            waiter: asyncio.Future[ControlConnection] = asyncio.get_event_loop().create_future()
+            self.waiters.append(waiter)
+
+        # Wait outside the lock
+        return await waiter
+
+    def release(self, cc: ControlConnection) -> None:
+        """Release a connection back to the pool.
+
+        Args:
+            cc: The connection to release
+        """
+        cc.op_active = False
+        cc.op_conn = None
+
+        # If there are waiters, give them this connection
+        if self.waiters:
+            waiter = self.waiters.pop(0)
+            cc.op_active = True  # Mark as in use again
+            waiter.set_result(cc)
+            return
+
+        # Try to drain idle connections if pool is large
+        self._try_drain()
+
+    def _try_drain(self) -> None:
+        """Drain idle connections when pool is large.
+
+        When pool size exceeds POOL_DRAIN_THRESHOLD, close idle connections
+        down to POOL_DRAIN_TARGET.
+        """
+        if self.closed or len(self.conns) <= POOL_DRAIN_THRESHOLD:
+            return
+
+        # Find idle connections (not active, not closed)
+        idle_conns = [
+            cc for cc in self.conns
+            if not cc.op_active and not cc.is_closed()
+        ]
+
+        # Sort by least recently used (we don't track last_used, so just take from end)
+        to_close = len(self.conns) - POOL_DRAIN_TARGET
+        if to_close <= 0:
+            return
+
+        # Close idle connections
+        closed = 0
+        for cc in idle_conns:
+            if closed >= to_close:
+                break
+            # Close async in background
+            asyncio.create_task(cc.close())
+            self.conns.remove(cc)
+            closed += 1
+
+    async def close(self) -> None:
+        """Close all connections in the pool."""
+        async with self._lock:
+            self.closed = True
+
+            # Cancel all waiters
+            for waiter in self.waiters:
+                waiter.cancel()
+            self.waiters = []
+
+            # Close all connections
+            for cc in self.conns:
+                await cc.close()
+            self.conns = []
+
+    def size(self) -> int:
+        """Return the current number of connections in the pool."""
+        return len(self.conns)
+
+    def has_connections(self) -> bool:
+        """Return True if the pool has any active connections."""
+        return len(self.conns) > 0
+
+
+# Module-level cache for control pools (one pool per sprite)
+_control_pools: Dict[str, ControlPool] = {}
+
+
+async def get_control_connection(sprite: Sprite) -> ControlConnection:
+    """Get a control connection from the pool for a sprite.
+
+    Args:
+        sprite: The sprite to connect to
+
+    Returns:
+        ControlConnection instance (caller must release when done)
+    """
+    key = f"{sprite.client.base_url}:{sprite.name}"
+
+    # Get or create pool
+    if key not in _control_pools:
+        _control_pools[key] = ControlPool(sprite)
+
+    pool = _control_pools[key]
+    return await pool.acquire()
+
+
+def release_control_connection(sprite: Sprite, cc: ControlConnection) -> None:
+    """Release a control connection back to the pool.
+
+    Args:
+        sprite: The sprite whose pool to release to
+        cc: The connection to release
+    """
+    key = f"{sprite.client.base_url}:{sprite.name}"
+
+    if key in _control_pools:
+        _control_pools[key].release(cc)
+
+
+async def close_control_connection(sprite: Sprite) -> None:
+    """Close the control pool for a sprite.
+
+    Args:
+        sprite: The sprite whose pool to close
+    """
+    key = f"{sprite.client.base_url}:{sprite.name}"
+
+    if key in _control_pools:
+        pool = _control_pools.pop(key)
+        await pool.close()
+
+
+def has_control_connection(sprite: Sprite) -> bool:
+    """Check if a sprite has any active control connections.
+
+    Args:
+        sprite: The sprite to check
+
+    Returns:
+        True if the sprite has active control connections
+    """
+    key = f"{sprite.client.base_url}:{sprite.name}"
+    if key not in _control_pools:
+        return False
+    return _control_pools[key].has_connections()
+
+
+async def _close_all_pools() -> None:
+    """Close all control pools. Called on program exit."""
+    pools = list(_control_pools.values())
+    _control_pools.clear()
+    for pool in pools:
+        try:
+            await pool.close()
+        except Exception:
+            pass  # Ignore errors during cleanup
+
+    # Give background tasks time to clean up
+    await asyncio.sleep(0.1)
+
+
+def _cleanup_on_exit() -> None:
+    """Cleanup handler called on program exit."""
+    if not _control_pools:
+        return
+
+    try:
+        from sprites.loop import get_loop, stop_loop
+
+        loop = get_loop()
+        future = asyncio.run_coroutine_threadsafe(_close_all_pools(), loop)
+        future.result(timeout=5)
+
+        # Stop the event loop thread
+        stop_loop()
+    except Exception:
+        pass  # Ignore errors during cleanup
+
+
+# Register cleanup handler
+import atexit
+atexit.register(_cleanup_on_exit)

--- a/src/sprites/exec.py
+++ b/src/sprites/exec.py
@@ -164,24 +164,11 @@ class Cmd:
         self._started = True
 
         try:
-            # Get or create event loop
-            try:
-                loop = asyncio.get_running_loop()
-                # We're already in an async context - need to run in new thread
-                import concurrent.futures
-
-                with concurrent.futures.ThreadPoolExecutor() as executor:
-                    future = executor.submit(self._run_in_new_loop)
-                    return future.result()
-            except RuntimeError:
-                # No running loop - we can create one
-                return asyncio.run(self._run_async())
+            # Use the persistent event loop for connection reuse
+            from sprites.loop import run_sync
+            return run_sync(self._run_async(), timeout=self.timeout)
         finally:
             self._finished = True
-
-    def _run_in_new_loop(self) -> int:
-        """Run the command in a new event loop."""
-        return asyncio.run(self._run_async())
 
     async def _run_async(self) -> int:
         """Run the command asynchronously."""

--- a/src/sprites/loop.py
+++ b/src/sprites/loop.py
@@ -1,0 +1,118 @@
+"""Persistent event loop for connection reuse in sync API."""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import threading
+from typing import Any, Coroutine, TypeVar
+
+T = TypeVar("T")
+
+# Module-level state for the persistent event loop
+_loop: asyncio.AbstractEventLoop | None = None
+_thread: threading.Thread | None = None
+_lock = threading.Lock()
+
+
+def _run_loop(loop: asyncio.AbstractEventLoop) -> None:
+    """Run the event loop in a background thread."""
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
+
+
+def get_loop() -> asyncio.AbstractEventLoop:
+    """Get or create the persistent event loop.
+
+    Returns:
+        The persistent event loop running in a background thread.
+    """
+    global _loop, _thread
+
+    with _lock:
+        if _loop is None or not _loop.is_running():
+            # Create a new event loop
+            _loop = asyncio.new_event_loop()
+
+            # Start it in a background daemon thread
+            _thread = threading.Thread(target=_run_loop, args=(_loop,), daemon=True)
+            _thread.start()
+
+            # Register cleanup on exit
+            atexit.register(_cleanup)
+
+    return _loop
+
+
+def run_sync(coro: Coroutine[Any, Any, T], timeout: float | None = None) -> T:
+    """Run a coroutine synchronously using the persistent event loop.
+
+    This allows connection reuse across multiple sync calls by running
+    all coroutines in the same persistent event loop.
+
+    Args:
+        coro: The coroutine to run.
+        timeout: Optional timeout in seconds.
+
+    Returns:
+        The result of the coroutine.
+
+    Raises:
+        TimeoutError: If the timeout is exceeded.
+        Exception: Any exception raised by the coroutine.
+    """
+    loop = get_loop()
+
+    # Submit the coroutine to the persistent loop
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+
+    try:
+        return future.result(timeout=timeout)
+    except TimeoutError:
+        future.cancel()
+        raise
+
+
+async def _cancel_all_tasks(loop: asyncio.AbstractEventLoop) -> None:
+    """Cancel all pending tasks in the loop."""
+    tasks = [t for t in asyncio.all_tasks(loop) if t is not asyncio.current_task()]
+    for task in tasks:
+        task.cancel()
+
+    if tasks:
+        # Wait for all tasks to be cancelled
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def stop_loop() -> None:
+    """Stop the persistent event loop.
+
+    This should be called when all async work is done and you want to
+    cleanly shut down the background thread.
+    """
+    global _loop, _thread
+
+    with _lock:
+        if _loop is not None and _loop.is_running():
+            # Cancel all pending tasks before stopping the loop
+            # This prevents "Task was destroyed but it is pending" warnings
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    _cancel_all_tasks(_loop), _loop
+                )
+                future.result(timeout=5.0)
+            except Exception:
+                pass
+
+            _loop.call_soon_threadsafe(_loop.stop)
+
+            if _thread is not None:
+                _thread.join(timeout=2.0)
+
+        _loop = None
+        _thread = None
+
+
+def _cleanup() -> None:
+    """Clean up the persistent event loop on exit."""
+    stop_loop()

--- a/src/sprites/sprite.py
+++ b/src/sprites/sprite.py
@@ -26,6 +26,7 @@ from .exceptions import (
 if TYPE_CHECKING:
     from .client import SpritesClient
     from .filesystem import SpriteFilesystem
+    from .control import ControlConnection
 
 
 class Sprite:
@@ -41,6 +42,9 @@ class Sprite:
         """
         self.name = name
         self.client = client
+
+        # Control mode support flag (set to False when 404 is received)
+        self._control_mode_supported: bool = True
 
         # Additional properties from API
         self.id: Optional[str] = None
@@ -543,3 +547,38 @@ class Sprite:
             raise SpriteError(
                 f"Failed to update network policy (status {response.status_code}): {response.text}"
             )
+
+    # ========== Control Connection API ==========
+
+    def use_control_mode(self) -> bool:
+        """Check if control mode is enabled for this sprite.
+
+        Returns:
+            True if control mode is enabled and supported by this sprite
+        """
+        return self.client.control_mode and self._control_mode_supported
+
+    async def get_control_connection(self) -> "ControlConnection":
+        """Get or create a control connection for multiplexed operations.
+
+        Returns:
+            ControlConnection instance
+        """
+        from .control import get_control_connection
+        return await get_control_connection(self)
+
+    async def close_control_connection(self) -> None:
+        """Close the control connection if open."""
+        from .control import close_control_connection
+        await close_control_connection(self)
+
+    def has_control_connection(self) -> bool:
+        """Check if this sprite has an active control connection.
+
+        This can be used to verify that control mode is being used.
+
+        Returns:
+            True if a control connection pool exists with active connections
+        """
+        from .control import has_control_connection
+        return has_control_connection(self)

--- a/src/sprites/websocket.py
+++ b/src/sprites/websocket.py
@@ -430,15 +430,20 @@ async def run_ws_command_via_control(cmd: Cmd) -> int:
 
     cc = None
     try:
+        # Double-check control mode is still supported (may have been disabled
+        # by another concurrent command that already got a 404)
+        if not cmd.sprite._control_mode_supported:
+            return await _run_ws_command_direct(cmd)
+
         # Get a control connection from the pool
         cc = await get_control_connection(cmd.sprite)
 
         # Build operation arguments
         args: dict[str, Any] = {"cmd": cmd.args}
 
-        # Add environment variables
+        # Add environment variables (pass dict - start_op converts to list)
         if cmd.env:
-            args["env"] = [f"{k}={v}" for k, v in cmd.env.items()]
+            args["env"] = cmd.env
 
         # Add working directory
         if cmd.dir:
@@ -455,6 +460,21 @@ async def run_ws_command_via_control(cmd: Cmd) -> int:
 
         # Start the exec operation
         op = await cc.start_op("exec", **args)
+
+        # Handle stdin
+        if cmd.stdin is not None:
+            loop = asyncio.get_event_loop()
+            try:
+                while True:
+                    data = await loop.run_in_executor(None, cmd.stdin.read, 4096)
+                    if not data:
+                        break
+                    await op.write(data)
+            except Exception:
+                pass
+            await op.send_eof()
+        else:
+            await op.send_eof()
 
         # Wait for operation to complete
         exit_code = await op.wait()

--- a/src/sprites/websocket.py
+++ b/src/sprites/websocket.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from urllib.parse import urlencode
 
 import websockets
-from websockets.exceptions import ConnectionClosed, InvalidStatusCode
+from websockets.exceptions import ConnectionClosed, InvalidStatusCode, InvalidStatus
 
 from sprites.exceptions import parse_api_error
 
@@ -352,6 +352,10 @@ async def run_ws_command(cmd: Cmd) -> int:
     Returns:
         The exit code of the command.
     """
+    # Use control mode if enabled (except for attach operations)
+    if cmd.session_id is None and cmd.sprite.use_control_mode():
+        return await run_ws_command_via_control(cmd)
+
     ws_cmd = WSCommand(cmd)
     ws_cmd.text_message_handler = cmd._text_message_handler
 
@@ -378,3 +382,106 @@ async def run_ws_command(cmd: Cmd) -> int:
         cmd._stderr_data = ws_cmd.get_stderr()
 
     return exit_code
+
+
+async def _run_ws_command_direct(cmd: Cmd) -> int:
+    """Run a command via direct WebSocket (no control mode).
+
+    Args:
+        cmd: The command to execute.
+
+    Returns:
+        The exit code of the command.
+    """
+    ws_cmd = WSCommand(cmd)
+    ws_cmd.text_message_handler = cmd._text_message_handler
+
+    try:
+        await ws_cmd.start()
+        exit_code = await ws_cmd.wait()
+    except Exception as e:
+        error_msg = f"WebSocket error: {type(e).__name__}: {e}\n"
+        ws_cmd._stderr_buffer.extend(error_msg.encode())
+        exit_code = 1
+    finally:
+        await ws_cmd.close()
+
+    # Copy buffered output if cmd is capturing
+    if cmd._capture_stdout:
+        cmd._stdout_data = ws_cmd.get_stdout()
+    if cmd._capture_stderr:
+        cmd._stderr_data = ws_cmd.get_stderr()
+    elif exit_code != 0:
+        cmd._stderr_data = ws_cmd.get_stderr()
+
+    return exit_code
+
+
+async def run_ws_command_via_control(cmd: Cmd) -> int:
+    """Run a command via the control connection for multiplexed operations.
+
+    Args:
+        cmd: The command to execute.
+
+    Returns:
+        The exit code of the command.
+    """
+    from sprites.control import get_control_connection, release_control_connection
+
+    cc = None
+    try:
+        # Get a control connection from the pool
+        cc = await get_control_connection(cmd.sprite)
+
+        # Build operation arguments
+        args: dict[str, Any] = {"cmd": cmd.args}
+
+        # Add environment variables
+        if cmd.env:
+            args["env"] = [f"{k}={v}" for k, v in cmd.env.items()]
+
+        # Add working directory
+        if cmd.dir:
+            args["dir"] = cmd.dir
+
+        # Add TTY settings
+        if cmd.tty:
+            args["tty"] = True
+            args["rows"] = cmd.tty_rows
+            args["cols"] = cmd.tty_cols
+
+        # Add stdin indicator
+        args["stdin"] = cmd.stdin is not None
+
+        # Start the exec operation
+        op = await cc.start_op("exec", **args)
+
+        # Wait for operation to complete
+        exit_code = await op.wait()
+
+        # Copy output
+        cmd._stdout_data = op.get_stdout()
+        cmd._stderr_data = op.get_stderr()
+
+        return exit_code
+
+    except (InvalidStatusCode, InvalidStatus) as e:
+        # Control endpoint returned error (likely 404) - fall back to direct mode
+        # Release connection if we got one
+        if cc is not None:
+            release_control_connection(cmd.sprite, cc)
+            cc = None
+        # Mark sprite as not supporting control mode to avoid repeated failures
+        cmd.sprite._control_mode_supported = False
+        # Retry with direct WebSocket
+        return await _run_ws_command_direct(cmd)
+
+    except Exception as e:
+        # If control mode fails for other reasons, store error message in stderr buffer
+        error_msg = f"Control mode error: {type(e).__name__}: {e}\n"
+        cmd._stderr_data = error_msg.encode()
+        return 1
+    finally:
+        # Always release the connection back to the pool
+        if cc is not None:
+            release_control_connection(cmd.sprite, cc)

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,0 +1,83 @@
+"""Tests for the control connection module."""
+
+import pytest
+from sprites import SpritesClient
+
+
+class TestControlModeClientOptions:
+    """Tests for control mode client options."""
+
+    def test_control_mode_false_by_default(self):
+        """Control mode should be disabled by default (opt-in)."""
+        client = SpritesClient(token="test-token")
+        assert client.control_mode is False
+
+    def test_control_mode_enabled_explicitly(self):
+        """Control mode should be enabled when explicitly specified."""
+        client = SpritesClient(token="test-token", control_mode=True)
+        assert client.control_mode is True
+
+    def test_control_mode_disabled_explicitly(self):
+        """Control mode should be disabled when explicitly set to False."""
+        client = SpritesClient(token="test-token", control_mode=False)
+        assert client.control_mode is False
+
+
+class TestSpriteControlMode:
+    """Tests for sprite control mode."""
+
+    def test_reflects_client_control_mode_true(self):
+        """Sprite should reflect client's control mode setting when True."""
+        client = SpritesClient(token="test-token", control_mode=True)
+        sprite = client.sprite("test-sprite")
+        assert sprite.use_control_mode() is True
+
+    def test_reflects_client_control_mode_false(self):
+        """Sprite should reflect client's control mode setting when False."""
+        client = SpritesClient(token="test-token", control_mode=False)
+        sprite = client.sprite("test-sprite")
+        assert sprite.use_control_mode() is False
+
+    def test_reflects_client_control_mode_default(self):
+        """Sprite should reflect default client control mode (False - disabled by default)."""
+        client = SpritesClient(token="test-token")
+        sprite = client.sprite("test-sprite")
+        assert sprite.use_control_mode() is False
+
+
+class TestControlURLBuilding:
+    """Tests for control endpoint URL building."""
+
+    def test_control_endpoint_url_http(self):
+        """Control endpoint URL should be built correctly for HTTP."""
+        client = SpritesClient(token="test-token", base_url="http://localhost:8080")
+        sprite = client.sprite("my-sprite")
+
+        expected_url = "ws://localhost:8080/v1/sprites/my-sprite/control"
+
+        # Build actual URL (simulating what ControlConnection does)
+        base_url = sprite.client.base_url
+        if base_url.startswith("https"):
+            base_url = "wss" + base_url[5:]
+        elif base_url.startswith("http"):
+            base_url = "ws" + base_url[4:]
+        actual_url = f"{base_url}/v1/sprites/{sprite.name}/control"
+
+        assert actual_url == expected_url
+
+    def test_control_endpoint_url_https(self):
+        """Control endpoint URL should convert HTTPS to WSS."""
+        client = SpritesClient(token="test-token", base_url="https://api.sprites.dev")
+        sprite = client.sprite("my-sprite")
+
+        # Build actual URL
+        base_url = sprite.client.base_url
+        if base_url.startswith("https"):
+            base_url = "wss" + base_url[5:]
+        elif base_url.startswith("http"):
+            base_url = "ws" + base_url[4:]
+        actual_url = f"{base_url}/v1/sprites/{sprite.name}/control"
+
+        assert actual_url.startswith("wss://")
+        assert "my-sprite" in actual_url
+        assert "/control" in actual_url


### PR DESCRIPTION
## Summary

- **Default `control_mode` to `False`** (opt-in) instead of `True` — servers that don't support the `/control` WebSocket endpoint no longer crash the SDK
- **Graceful fallback** to direct WebSocket when control endpoint returns 404, with per-sprite tracking via `_control_mode_supported` flag
- Restores all control connection code reverted in #14

## Context

Control mode was merged in #13 with `control_mode=True` as the default. This broke the `sprite-env` release pipeline because the example generator runs commands against sprites that don't have control connection support. The revert (#14) removed all control mode code.

This PR re-applies the control mode implementation with fixes to prevent the same breakage.

## Test plan

- [x] Unit tests pass (`pytest tests/test_control.py` — 8 tests)
- [x] E2E test passes on sprite with control support (`test123` — all 5 tests pass)
- [x] E2E test passes on sprite without control support (`test1234` — commands fall back to direct WebSocket)
- [ ] After merging, update `sprite-env` submodule pointer for `sdks/python` and verify example generation succeeds