### PR TITLE
Fix process hangs: add timeouts and fix atexit handler conflict

### DIFF
--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -13,7 +13,7 @@ client = SpritesClient(os.environ["SPRITE_TOKEN"])
 client.create_sprite(os.environ["SPRITE_NAME"])
 
 # step: Run Python
-output = client.sprite(os.environ["SPRITE_NAME"]).command("python", "-c", "print(2+2)").output()
+output = client.sprite(os.environ["SPRITE_NAME"]).command("python", "-c", "print(2+2)", timeout=30).output()
 print(output.decode(), end="")
 
 # step: Clean up

--- a/src/sprites/checkpoint.py
+++ b/src/sprites/checkpoint.py
@@ -217,9 +217,9 @@ def create_checkpoint(sprite: Sprite, comment: str = "") -> CheckpointStream:
     if comment:
         payload["comment"] = comment
 
-    # Use a separate client for streaming with no timeout
+    # Use a separate client for streaming with a generous timeout
     with httpx.Client(
-        timeout=None,
+        timeout=300.0,
         headers={"Authorization": f"Bearer {sprite.client.token}"},
     ) as client:
         try:
@@ -269,9 +269,9 @@ def restore_checkpoint(sprite: Sprite, checkpoint_id: str) -> RestoreStream:
     """
     url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/checkpoints/{checkpoint_id}/restore"
 
-    # Use a separate client for streaming with no timeout
+    # Use a separate client for streaming with a generous timeout
     with httpx.Client(
-        timeout=None,
+        timeout=300.0,
         headers={"Authorization": f"Bearer {sprite.client.token}"},
     ) as client:
         try:

--- a/src/sprites/control.py
+++ b/src/sprites/control.py
@@ -645,7 +645,12 @@ def _cleanup_on_exit() -> None:
         return
 
     try:
-        from sprites.loop import get_loop, stop_loop
+        from sprites.loop import get_loop, stop_loop, _loop
+
+        # Don't create a new loop just for cleanup — if the loop was already
+        # stopped by loop.py's atexit handler, just skip cleanup
+        if _loop is None:
+            return
 
         loop = get_loop()
         future = asyncio.run_coroutine_threadsafe(_close_all_pools(), loop)


### PR DESCRIPTION
## Summary

- **Fix atexit handler conflict** — `control.py`'s atexit handler could create a new event loop after `loop.py`'s handler already stopped it (LIFO ordering), causing a hang during shutdown. Now checks if `_loop` is `None` before attempting cleanup.
- **Add HTTP timeouts to checkpoint operations** — `checkpoint.py` used `timeout=None` for create/restore, meaning requests could block forever. Changed to 300s (5 minutes).
- **Add timeout to quickstart example** — `quickstart.py` now uses `timeout=30` on the command call to prevent indefinite blocking.