### PR TITLE
Fix ServiceWithState construction in services

### DIFF
--- a/src/sprites/services.py
+++ b/src/sprites/services.py
@@ -100,7 +100,14 @@ def _parse_service_with_state(data: dict) -> ServiceWithState:
             restart_count=state_data.get("restart_count", 0),
         )
 
-    return ServiceWithState(service=service, state=state)
+    return ServiceWithState(
+        name=service.name,
+        cmd=service.cmd,
+        args=service.args,
+        needs=service.needs,
+        http_port=service.http_port,
+        state=state,
+    )
 
 
 def _parse_stream_response(response_text: str) -> list[ServiceLogEvent]:


### PR DESCRIPTION
Refs superfly/sprites-py#19. Fixes constructor callsite mismatch that blocks being able to use Services in Python SDK.

(Apologies for mixing up my issue numbers, had it as # 18 on accident a moment ago, and the branch is still misnamed)