### PR TITLE
Fix TimeoutError construction in exec

### DIFF
--- a/src/sprites/exec.py
+++ b/src/sprites/exec.py
@@ -179,9 +179,7 @@ class Cmd:
                 async with asyncio.timeout(self.timeout):
                     return await run_ws_command(self)
             except asyncio.TimeoutError:
-                raise TimeoutError(
-                    f"command timed out after {self.timeout}s", timeout=self.timeout
-                ) from None
+                raise TimeoutError(f"command timed out after {self.timeout}s") from None
         else:
             return await run_ws_command(self)
 


### PR DESCRIPTION
Refs superfly/sprites-py#18. Small API drift fix.