### PR TITLE
Fix attach session race that drops live frames

### DIFF
--- a/src/sprites/websocket.py
+++ b/src/sprites/websocket.py
@@ -131,15 +131,21 @@ class WSCommand:
             # Fall back to original exception
             raise
 
-        # Start I/O loop in background IMMEDIATELY after connect
-        # This must happen before any other awaits to avoid missing messages
+        # When attaching to an existing session, drain the session_info text
+        # frame BEFORE starting the I/O loop. Both `_wait_for_session_info`
+        # and `_run_io` iterate `async for message in self.ws`, and the
+        # `websockets` library does not support concurrent reads on the same
+        # connection — running them in parallel splits messages between the
+        # two coroutines unpredictably, causing live binary frames (stdout/
+        # stderr/exit) on the attach side to be silently dropped.
+        if self._is_attach:
+            await self._wait_for_session_info()
+
+        # Start I/O loop in background IMMEDIATELY after connect (or after
+        # session_info has been drained on attach).
         self._io_task = asyncio.create_task(self._run_io())
         # Yield to let the I/O task start reading before we return
         await asyncio.sleep(0)
-
-        # When attaching to an existing session, wait for session_info to determine TTY mode
-        if self._is_attach:
-            await self._wait_for_session_info()
 
     async def _wait_for_session_info(self) -> None:
         """Wait for session_info message when attaching."""


### PR DESCRIPTION
## Summary

`WSCommand.start()` creates the `_run_io` background task **before** calling `_wait_for_session_info()` on attach. Both coroutines then iterate `async for message in self.ws` against the same WebSocket. The `websockets` library does not support concurrent reads on a single connection — messages get split between the two coroutines unpredictably, and `_wait_for_session_info` silently drops any binary frames it happens to consume while waiting for the `session_info` text frame.

The visible symptom: a client that calls `sprite.attach_session(id)` reliably receives the **replayed scrollback** but loses subsequent **live** stdout/stderr/exit frames.

## Fix

Drain `_wait_for_session_info` to completion **before** scheduling the `_run_io` task. There is then only ever one reader on the WebSocket at a time, and live binary frames are delivered in full.

```diff
-        self._io_task = asyncio.create_task(self._run_io())
-        await asyncio.sleep(0)
-
-        if self._is_attach:
-            await self._wait_for_session_info()
+        if self._is_attach:
+            await self._wait_for_session_info()
+
+        self._io_task = asyncio.create_task(self._run_io())
+        await asyncio.sleep(0)
```

## Reproduction

Against a live sprite running `bash -c 'for i in $(seq 1 30); do echo tick=$i; sleep 1; done'`:

**Before** — second client opened via `sprite.attach_session(id)` sees the replay and then nothing:
```
[reattached] tick=1
[reattached] tick=2
[reattached] tick=3
(no live ticks ever arrive on the reattached connection)
```

**After** — same setup, second client sees replay AND live frames in lockstep with the original exec:
```
[reattached] tick=1
[reattached] tick=2
[reattached] tick=3
[reattached] tick=4
[reattached] tick=5
...
```

A raw-WebSocket probe (bypassing the SDK) confirmed the server has always been streaming live frames to attach connections — the bug was purely client-side.

## Test plan

- [x] All 24 existing tests in `tests/` still pass (`pytest tests/`)
- [x] Verified against a live sprite end-to-end with `sprite.attach_session(id)` from the patched source
- [ ] No new tests added — the existing suite has no WebSocket-level coverage and stubbing the `websockets` async iterator semantics would balloon scope; happy to add one if you'd like