### PR TITLE
Set close_timeout=0 on exec WebSocket (~38x exec speedup)

### DIFF
--- a/src/sprites/websocket.py
+++ b/src/sprites/websocket.py
@@ -114,6 +114,13 @@ class WSCommand:
                 ping_interval=WS_PING_INTERVAL,
                 ping_timeout=WS_PONG_WAIT,
                 max_size=10 * 1024 * 1024,  # 10MB max message size
+                # The server holds the WS open for ~5s after sending EXIT
+                # before initiating its own close. The Elixir SDK doesn't
+                # wait at all — it sends a CLOSE frame and tears the TCP.
+                # Mirror that: close_timeout=0 sends CLOSE without awaiting
+                # the server's reciprocal frame, dropping per-exec latency
+                # from ~5.3s to ~140ms (a ~38x speedup). See #24.
+                close_timeout=0,
             )
         except InvalidStatusCode as e:
             # Try to parse as a structured API error


### PR DESCRIPTION
Closes #24.

## Summary

`websockets.connect()` in `WSCommand.start` is called without an explicit `close_timeout`, so it inherits the library default of 10s. After the server sends the EXIT byte it holds the WebSocket open for ~5s before initiating its own close handshake — the client's `await ws.close()` blocks waiting for that reply, adding a fixed ~5s tax to every exec. Full root-cause analysis and phase-by-phase timings in #24.

## Fix

Mirror the Elixir SDK's behavior. [`sprites-ex`](https://github.com/superfly/sprites-ex/blob/main/lib/sprites/command.ex#L317-L324) sends a CLOSE frame via `:gun.ws_send` on EXIT and immediately calls `:gun.close` to tear down the TCP — it never waits for the server's reciprocal CLOSE. `close_timeout=0` in `websockets`-lib produces the same shape: the CLOSE frame is sent, but `ws.close()` returns immediately rather than awaiting the server.

```diff
 self.ws = await websockets.connect(
     url,
     additional_headers=headers,
     ping_interval=WS_PING_INTERVAL,
     ping_timeout=WS_PONG_WAIT,
     max_size=10 * 1024 * 1024,
+    close_timeout=0,
 )
```

## Impact

Side-by-side bench against a warm sprite running `cat /tmp/x` (n=3, p50):

| `close_timeout` | per-exec latency | speedup |
|---|---|---|
| 10s (library default) | ~5,300ms | — |
| 0.5s | ~650ms | 8× |
| **0** | **~140ms** | **38×** |

This puts `sprites-py` on parity with `sprites-ex` on the exec hot path. Cross-SDK bench (n=3, p50):

| phase | sprites-py | sprites-ex |
|---|---|---|
| exec_first | 128ms | 156ms |
| exec_warm_avg | 121ms | 188ms |

## Behavior change

The client no longer waits for the server's reciprocal CLOSE frame. The CLOSE frame is still sent — the server will see a clean close — we just don't block our own coroutine waiting on it. There is no resource leak: the underlying TCP socket is torn down by `websockets`-lib's normal cleanup path regardless.