### PR TITLE
Update SDK for current Sprites API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.2.0
+
+- Updated the SDK for the current Sprites API response and request shapes.
+- Added `destroy`/`destroy_sprite` as the preferred sprite removal terminology while keeping `delete`/`delete_sprite` aliases.
+- Added public methods for mutable sprite updates, services, filesystem operations, and subprocess-style `Sprite.run()`.
+- `ServiceWithState` now exposes service fields directly, such as `service.name`; the older nested `service.service.name` shape is no longer used.
+- `ServiceState.started_at` and `ServiceState.next_restart_at` are parsed as `datetime` values instead of raw strings.
+- Added mocked API contract and public-method tests for the client, sprite, filesystem, services, checkpoints, and streams.

--- a/README.md
+++ b/README.md
@@ -73,12 +73,17 @@ updated = client.update_sprite(
     labels=["dev", "public-demo"],
 )
 
+# Omitted mutable fields are left unchanged by the API.
+client.update_sprite("my-sprite", labels=["dev"])
+
 # Destroy a sprite
 client.destroy_sprite("my-sprite")
 ```
 
 `URLSettings.auth` is `"sprite"` or `"public"`. When `auth="sprite"`,
-`private_access` may be `"admins"` or `"org_users"`.
+`private_access` may be `"admins"` or `"org_users"`. `update_url_settings(...)`
+is kept as a compatibility convenience for updating only URL settings; prefer
+`update_sprite(...)` when changing mutable sprite fields.
 
 ### Sprite
 
@@ -106,6 +111,8 @@ cmd.run()
 Commands use WebSockets. If `control_mode=True` is passed to `SpritesClient`,
 new commands use the multiplexed control connection when the sprite supports it
 and fall back to the standard exec WebSocket otherwise.
+Use `sprite.command(...)` instead of `sprite.run(...)` when you need streaming
+stdin/stdout/stderr handles.
 
 ### Filesystem
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Sprites Python SDK
 
-Python SDK for [Sprites](https://sprites.dev) - remote command execution platform.
+Python SDK for [Sprites](https://sprites.dev), providing sprite management,
+remote command execution, filesystem access, checkpoints, services, and network
+policy controls.
 
 ## Installation
 
@@ -11,13 +13,12 @@ pip install sprites-py
 ## Quick Start
 
 ```python
+import os
+
 from sprites import SpritesClient
 
-# Create a client
-client = SpritesClient(token="your-token")
-
-# Get a sprite handle
-sprite = client.sprite("my-sprite")
+client = SpritesClient(token=os.environ["SPRITE_TOKEN"])
+sprite = client.create_sprite(os.environ["SPRITE_NAME"])
 
 # Run a command
 result = sprite.run("echo", "hello", capture_output=True)
@@ -27,6 +28,8 @@ print(result.stdout.decode())  # "hello\n"
 cmd = sprite.command("ls", "-la")
 output = cmd.output()
 print(output.decode())
+
+sprite.destroy()
 ```
 
 ## API Overview
@@ -34,23 +37,48 @@ print(output.decode())
 ### SpritesClient
 
 ```python
-from sprites import SpritesClient
+from sprites import ListOptions, SpritesClient, URLSettings
 
 client = SpritesClient(
     token="your-token",
     base_url="https://api.sprites.dev",  # optional
     timeout=30.0,  # optional
+    control_mode=False,  # optional multiplexed exec transport
 )
 
 # Create a sprite
-sprite = client.create_sprite("my-sprite")
+sprite = client.create_sprite(
+    "my-sprite",
+    url_settings=URLSettings(auth="sprite", private_access="admins"),
+    labels=["dev"],
+    wait_for_capacity=True,
+    runtime="dev",
+)
 
 # Get a sprite handle (doesn't create it)
 sprite = client.sprite("my-sprite")
 
-# Delete a sprite
-client.delete_sprite("my-sprite")
+# Get a sprite with populated metadata
+sprite = client.get_sprite("my-sprite")
+
+# List sprites
+page = client.list_sprites(ListOptions(prefix="my-", bulk_load=True))
+for item in page.sprites:
+    print(item.name, item.status, item.labels)
+
+# Update URL settings and labels
+updated = client.update_sprite(
+    "my-sprite",
+    url_settings=URLSettings(auth="public"),
+    labels=["dev", "public-demo"],
+)
+
+# Destroy a sprite
+client.destroy_sprite("my-sprite")
 ```
+
+`URLSettings.auth` is `"sprite"` or `"public"`. When `auth="sprite"`,
+`private_access` may be `"admins"` or `"org_users"`.
 
 ### Sprite
 
@@ -68,6 +96,27 @@ combined = cmd.combined_output()  # Returns stdout + stderr
 # TTY mode
 cmd = sprite.command("bash", tty=True, tty_rows=24, tty_cols=80)
 cmd.run()
+
+# Attach to an existing session
+sessions = sprite.list_sessions()
+cmd = sprite.attach_session(sessions[0].id, timeout=2)
+cmd.run()
+```
+
+Commands use WebSockets. If `control_mode=True` is passed to `SpritesClient`,
+new commands use the multiplexed control connection when the sprite supports it
+and fall back to the standard exec WebSocket otherwise.
+
+### Filesystem
+
+```python
+fs = sprite.filesystem("/app")
+
+(fs / "config.json").write_text('{"debug": true}')
+print((fs / "config.json").read_text())
+
+for path in (fs / ".").iterdir():
+    print(path.name)
 ```
 
 ### Checkpoints
@@ -87,10 +136,30 @@ for msg in stream:
     print(msg.type, msg.data)
 ```
 
+### Services
+
+```python
+# Create or update a service and stream startup events
+stream = sprite.create_service(
+    "web",
+    cmd="python",
+    args=["-m", "http.server", "8000"],
+    http_port=8000,
+)
+for event in stream:
+    print(event.type, event.data)
+
+# Inspect and control services
+services = sprite.list_services()
+web = sprite.get_service("web")
+sprite.stop_service("web")
+sprite.start_service("web")
+```
+
 ### Network Policy
 
 ```python
-from sprites.types import NetworkPolicy, PolicyRule
+from sprites import NetworkPolicy, PolicyRule
 
 # Get current policy
 policy = sprite.get_network_policy()
@@ -104,7 +173,7 @@ sprite.update_network_policy(new_policy)
 
 ## Requirements
 
-- Python 3.11+
+- Python 3.9+
 - websockets
 - httpx
 

--- a/examples/exec.py
+++ b/examples/exec.py
@@ -15,11 +15,11 @@ sprite = client.sprite(sprite_name)
 # Start a command that runs for 30s (TTY sessions stay alive after disconnect)
 cmd = sprite.command(
     "python", "-c",
-    "import time; print('Server ready on port 8080', flush=True); time.sleep(30)"
+    "import time; print('Server ready on port 8080', flush=True); time.sleep(30)",
+    tty=True,
+    stdout=sys.stdout.buffer,
+    timeout=2,
 )
-cmd.tty = True  # TTY sessions are detachable
-cmd.stdout = sys.stdout.buffer  # Stream output directly
-cmd.timeout = 2  # Disconnect after 2 seconds (session keeps running)
 
 try:
     cmd.run()

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -13,8 +13,13 @@ client = SpritesClient(os.environ["SPRITE_TOKEN"])
 client.create_sprite(os.environ["SPRITE_NAME"])
 
 # step: Run Python
-output = client.sprite(os.environ["SPRITE_NAME"]).command("python", "-c", "print(2+2)").output()
-print(output.decode(), end="")
+result = client.sprite(os.environ["SPRITE_NAME"]).run(
+    "python",
+    "-c",
+    "print(2+2)",
+    capture_output=True,
+)
+print(result.stdout.decode(), end="")
 
 # step: Clean up
-client.delete_sprite(os.environ["SPRITE_NAME"])
+client.destroy_sprite(os.environ["SPRITE_NAME"])

--- a/examples/service_create.py
+++ b/examples/service_create.py
@@ -5,7 +5,6 @@ import json
 import os
 
 from sprites import SpritesClient
-from sprites.services import create_service
 
 token = os.environ["SPRITE_TOKEN"]
 sprite_name = os.environ["SPRITE_NAME"]
@@ -14,9 +13,8 @@ service_name = os.environ["SERVICE_NAME"]
 client = SpritesClient(token)
 sprite = client.sprite(sprite_name)
 
-stream = create_service(
-    sprite,
-    name=service_name,
+stream = sprite.create_service(
+    service_name=service_name,
     cmd="python",
     args=["-m", "http.server", "8000"],
     http_port=8000,

--- a/examples/service_start.py
+++ b/examples/service_start.py
@@ -5,7 +5,6 @@ import json
 import os
 
 from sprites import SpritesClient
-from sprites.services import start_service
 
 token = os.environ["SPRITE_TOKEN"]
 sprite_name = os.environ["SPRITE_NAME"]
@@ -14,7 +13,7 @@ service_name = os.environ["SERVICE_NAME"]
 client = SpritesClient(token)
 sprite = client.sprite(sprite_name)
 
-stream = start_service(sprite, name=service_name)
+stream = sprite.start_service(service_name)
 
 for event in stream:
     print(json.dumps({"type": event.type, "timestamp": event.timestamp}))

--- a/examples/service_stop.py
+++ b/examples/service_stop.py
@@ -5,7 +5,6 @@ import json
 import os
 
 from sprites import SpritesClient
-from sprites.services import stop_service
 
 token = os.environ["SPRITE_TOKEN"]
 sprite_name = os.environ["SPRITE_NAME"]
@@ -14,7 +13,7 @@ service_name = os.environ["SERVICE_NAME"]
 client = SpritesClient(token)
 sprite = client.sprite(sprite_name)
 
-stream = stop_service(sprite, name=service_name)
+stream = sprite.stop_service(service_name)
 
 for event in stream:
     print(json.dumps({"type": event.type, "timestamp": event.timestamp}))

--- a/examples/sprite_create.py
+++ b/examples/sprite_create.py
@@ -3,13 +3,17 @@
 
 import os
 
-from sprites import SpritesClient
+from sprites import SpritesClient, URLSettings
 
 token = os.environ["SPRITE_TOKEN"]
 sprite_name = os.environ["SPRITE_NAME"]
 
 client = SpritesClient(token)
 
-client.create_sprite(sprite_name)
+client.create_sprite(
+    sprite_name,
+    url_settings=URLSettings(auth="sprite", private_access="admins"),
+    labels=["example"],
+)
 
 print(f"Sprite '{sprite_name}' created")

--- a/examples/sprite_destroy.py
+++ b/examples/sprite_destroy.py
@@ -10,6 +10,6 @@ sprite_name = os.environ["SPRITE_NAME"]
 
 client = SpritesClient(token)
 
-client.delete_sprite(sprite_name)
+client.destroy_sprite(sprite_name)
 
 print(f"Sprite '{sprite_name}' destroyed")

--- a/examples/sprite_get.py
+++ b/examples/sprite_get.py
@@ -20,5 +20,12 @@ if sprite.status:
     result["status"] = sprite.status
 if sprite.url:
     result["url"] = sprite.url
+if sprite.url_settings:
+    result["url_settings"] = {
+        "auth": sprite.url_settings.auth,
+        "private_access": sprite.url_settings.private_access,
+    }
+if sprite.labels:
+    result["labels"] = sprite.labels
 
 print(json.dumps(result, indent=2))

--- a/examples/sprite_list.py
+++ b/examples/sprite_list.py
@@ -4,13 +4,13 @@
 import json
 import os
 
-from sprites import SpritesClient
+from sprites import ListOptions, SpritesClient
 
 token = os.environ["SPRITE_TOKEN"]
 
 client = SpritesClient(token)
 
-sprites = client.list_sprites()
+sprites = client.list_sprites(ListOptions(bulk_load=True))
 
 result = []
 for s in sprites.sprites:
@@ -21,6 +21,15 @@ for s in sprites.sprites:
         item["status"] = s.status
     if s.url:
         item["url"] = s.url
+    if s.labels:
+        item["labels"] = s.labels
     result.append(item)
 
-print(json.dumps(result, indent=2))
+print(json.dumps({
+    "sprites": result,
+    "has_more": sprites.has_more,
+    "next_continuation_token": sprites.next_continuation_token,
+    "running": sprites.running,
+    "warm": sprites.warm,
+    "cold": sprites.cold,
+}, indent=2))

--- a/examples/sprite_update.py
+++ b/examples/sprite_update.py
@@ -10,6 +10,10 @@ sprite_name = os.environ["SPRITE_NAME"]
 
 client = SpritesClient(token)
 
-client.update_url_settings(sprite_name, URLSettings(auth="public"))
+sprite = client.update_sprite(
+    sprite_name,
+    url_settings=URLSettings(auth="public"),
+    labels=["example", "public-demo"],
+)
 
-print("URL settings updated")
+print(f"Sprite '{sprite.name}' updated")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sprites-py"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python SDK for the Sprites API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/sprites/__init__.py
+++ b/src/sprites/__init__.py
@@ -1,8 +1,9 @@
 """
 Sprites SDK for Python
 
-A Python SDK for interacting with the Sprites API, providing filesystem,
-checkpoint, services, and network policy management.
+A Python SDK for interacting with the Sprites API, providing sprite management,
+command execution, filesystem access, checkpoints, services, network policy
+management, and optional control-mode WebSocket multiplexing.
 
 Usage:
     from sprites import SpritesClient

--- a/src/sprites/__init__.py
+++ b/src/sprites/__init__.py
@@ -63,7 +63,7 @@ from .types import (
     DirEntry,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     # Main classes

--- a/src/sprites/_utils.py
+++ b/src/sprites/_utils.py
@@ -1,0 +1,69 @@
+"""Internal helpers for API parsing and URL construction."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+from urllib.parse import quote
+
+from .types import SpriteInfo, URLSettings
+
+
+def quote_path_segment(value: str) -> str:
+    """Quote a single URL path segment."""
+    return quote(value, safe="")
+
+
+def sprite_base_url(base_url: str, name: str) -> str:
+    """Build the base REST URL for a sprite."""
+    return f"{base_url.rstrip('/')}/v1/sprites/{quote_path_segment(name)}"
+
+
+def websocket_base_url(base_url: str) -> str:
+    """Convert an HTTP(S) base URL to a WS(S) base URL."""
+    if base_url.startswith("https"):
+        return "wss" + base_url[5:]
+    if base_url.startswith("http"):
+        return "ws" + base_url[4:]
+    return base_url
+
+
+def parse_datetime(value: Any) -> Optional[datetime]:
+    """Parse API datetime strings, returning None for missing or invalid values."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def parse_url_settings(data: Any) -> Optional[URLSettings]:
+    """Parse URL settings from an API response."""
+    if not isinstance(data, dict):
+        return None
+    return URLSettings(
+        auth=data.get("auth"),
+        private_access=data.get("private_access"),
+    )
+
+
+def parse_sprite_info(data: dict[str, Any]) -> SpriteInfo:
+    """Parse sprite metadata from an API response."""
+    return SpriteInfo(
+        id=data.get("id", ""),
+        name=data.get("name", ""),
+        organization=data.get("organization") or data.get("org_slug", ""),
+        status=data.get("status", ""),
+        created_at=parse_datetime(data.get("created_at")),
+        updated_at=parse_datetime(data.get("updated_at")),
+        bucket_name=data.get("bucket_name"),
+        primary_region=data.get("primary_region"),
+        url=data.get("url"),
+        url_settings=parse_url_settings(data.get("url_settings")),
+        version=data.get("version"),
+        environment_version=data.get("environment_version"),
+        labels=data.get("labels") or [],
+        last_running_at=parse_datetime(data.get("last_running_at")),
+        last_warming_at=parse_datetime(data.get("last_warming_at")),
+    )

--- a/src/sprites/checkpoint.py
+++ b/src/sprites/checkpoint.py
@@ -5,19 +5,15 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from typing import TYPE_CHECKING, Iterator
-from urllib.parse import quote
 
 import httpx
 
 from sprites.exceptions import APIError
 from sprites.types import Checkpoint, StreamMessage
+from sprites._utils import quote_path_segment, sprite_base_url
 
 if TYPE_CHECKING:
     from sprites.sprite import Sprite
-
-
-def _sprite_base_url(sprite: Sprite) -> str:
-    return f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
 
 
 class CheckpointStream:
@@ -137,7 +133,7 @@ def list_checkpoints(sprite: Sprite, history_filter: str = "") -> list[Checkpoin
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{_sprite_base_url(sprite)}/checkpoints"
+    url = f"{sprite_base_url(sprite.client.base_url, sprite.name)}/checkpoints"
     if history_filter:
         url += f"?history={history_filter}"
 
@@ -180,7 +176,10 @@ def get_checkpoint(sprite: Sprite, checkpoint_id: str) -> Checkpoint:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{_sprite_base_url(sprite)}/checkpoints/{quote(checkpoint_id, safe='')}"
+    url = (
+        f"{sprite_base_url(sprite.client.base_url, sprite.name)}"
+        f"/checkpoints/{quote_path_segment(checkpoint_id)}"
+    )
 
     try:
         response = sprite.client.http_client.get(url)
@@ -216,7 +215,7 @@ def create_checkpoint(sprite: Sprite, comment: str = "") -> CheckpointStream:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{_sprite_base_url(sprite)}/checkpoint"
+    url = f"{sprite_base_url(sprite.client.base_url, sprite.name)}/checkpoint"
 
     payload = {}
     if comment:
@@ -272,7 +271,10 @@ def restore_checkpoint(sprite: Sprite, checkpoint_id: str) -> RestoreStream:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{_sprite_base_url(sprite)}/checkpoints/{quote(checkpoint_id, safe='')}/restore"
+    url = (
+        f"{sprite_base_url(sprite.client.base_url, sprite.name)}"
+        f"/checkpoints/{quote_path_segment(checkpoint_id)}/restore"
+    )
 
     # Use a separate client for streaming with no timeout
     with httpx.Client(

--- a/src/sprites/checkpoint.py
+++ b/src/sprites/checkpoint.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from typing import TYPE_CHECKING, Iterator
+from urllib.parse import quote
 
 import httpx
 
@@ -13,6 +14,10 @@ from sprites.types import Checkpoint, StreamMessage
 
 if TYPE_CHECKING:
     from sprites.sprite import Sprite
+
+
+def _sprite_base_url(sprite: Sprite) -> str:
+    return f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
 
 
 class CheckpointStream:
@@ -132,7 +137,7 @@ def list_checkpoints(sprite: Sprite, history_filter: str = "") -> list[Checkpoin
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/checkpoints"
+    url = f"{_sprite_base_url(sprite)}/checkpoints"
     if history_filter:
         url += f"?history={history_filter}"
 
@@ -175,7 +180,7 @@ def get_checkpoint(sprite: Sprite, checkpoint_id: str) -> Checkpoint:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/checkpoints/{checkpoint_id}"
+    url = f"{_sprite_base_url(sprite)}/checkpoints/{quote(checkpoint_id, safe='')}"
 
     try:
         response = sprite.client.http_client.get(url)
@@ -211,7 +216,7 @@ def create_checkpoint(sprite: Sprite, comment: str = "") -> CheckpointStream:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/checkpoint"
+    url = f"{_sprite_base_url(sprite)}/checkpoint"
 
     payload = {}
     if comment:
@@ -267,7 +272,7 @@ def restore_checkpoint(sprite: Sprite, checkpoint_id: str) -> RestoreStream:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/checkpoints/{checkpoint_id}/restore"
+    url = f"{_sprite_base_url(sprite)}/checkpoints/{quote(checkpoint_id, safe='')}/restore"
 
     # Use a separate client for streaming with no timeout
     with httpx.Client(

--- a/src/sprites/client.py
+++ b/src/sprites/client.py
@@ -4,7 +4,6 @@ Sprites client implementation
 
 from datetime import datetime
 from typing import Any, Dict, List, Optional
-from urllib.parse import quote
 import httpx
 
 from .types import (
@@ -20,6 +19,12 @@ from .exceptions import (
     NetworkError,
     AuthenticationError,
     NotFoundError,
+)
+from ._utils import (
+    parse_datetime,
+    parse_sprite_info,
+    parse_url_settings,
+    sprite_base_url,
 )
 
 
@@ -86,45 +91,19 @@ class SpritesClient:
             )
 
     def _sprite_url(self, name: str) -> str:
-        return f"{self.base_url}/v1/sprites/{quote(name, safe='')}"
+        return sprite_base_url(self.base_url, name)
 
     @staticmethod
     def _parse_datetime(value: Any) -> Optional[datetime]:
-        if not value:
-            return None
-        try:
-            return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-        except ValueError:
-            return None
+        return parse_datetime(value)
 
     @classmethod
     def _parse_url_settings(cls, data: Any) -> Optional[URLSettings]:
-        if not isinstance(data, dict):
-            return None
-        return URLSettings(
-            auth=data.get("auth"),
-            private_access=data.get("private_access"),
-        )
+        return parse_url_settings(data)
 
     @classmethod
     def _parse_sprite_info(cls, data: Dict[str, Any]) -> SpriteInfo:
-        return SpriteInfo(
-            id=data.get("id", ""),
-            name=data.get("name", ""),
-            organization=data.get("organization") or data.get("org_slug", ""),
-            status=data.get("status", ""),
-            created_at=cls._parse_datetime(data.get("created_at")),
-            updated_at=cls._parse_datetime(data.get("updated_at")),
-            bucket_name=data.get("bucket_name"),
-            primary_region=data.get("primary_region"),
-            url=data.get("url"),
-            url_settings=cls._parse_url_settings(data.get("url_settings")),
-            version=data.get("version"),
-            environment_version=data.get("environment_version"),
-            labels=data.get("labels") or [],
-            last_running_at=cls._parse_datetime(data.get("last_running_at")),
-            last_warming_at=cls._parse_datetime(data.get("last_warming_at")),
-        )
+        return parse_sprite_info(data)
 
     def sprite(self, name: str) -> "Sprite":
         """
@@ -358,6 +337,9 @@ class SpritesClient:
         """
         Update URL authentication settings for a sprite.
 
+        This is a compatibility convenience for updating only URL settings.
+        Prefer update_sprite(...) when changing mutable sprite fields.
+
         Args:
             name: Sprite name
             settings: URL settings with auth: "public" for no auth, "sprite" for authenticated
@@ -389,6 +371,9 @@ class SpritesClient:
     ) -> "Sprite":
         """
         Update mutable sprite settings.
+
+        The Sprites API applies this as a partial update: omitted mutable fields
+        are left unchanged.
 
         Args:
             name: Sprite name

--- a/src/sprites/client.py
+++ b/src/sprites/client.py
@@ -2,7 +2,9 @@
 Sprites client implementation
 """
 
+from datetime import datetime
 from typing import Any, Dict, List, Optional
+from urllib.parse import quote
 import httpx
 
 from .types import (
@@ -83,6 +85,47 @@ class SpritesClient:
                 f"Failed {operation} (status {response.status_code}): {body}"
             )
 
+    def _sprite_url(self, name: str) -> str:
+        return f"{self.base_url}/v1/sprites/{quote(name, safe='')}"
+
+    @staticmethod
+    def _parse_datetime(value: Any) -> Optional[datetime]:
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+
+    @classmethod
+    def _parse_url_settings(cls, data: Any) -> Optional[URLSettings]:
+        if not isinstance(data, dict):
+            return None
+        return URLSettings(
+            auth=data.get("auth"),
+            private_access=data.get("private_access"),
+        )
+
+    @classmethod
+    def _parse_sprite_info(cls, data: Dict[str, Any]) -> SpriteInfo:
+        return SpriteInfo(
+            id=data.get("id", ""),
+            name=data.get("name", ""),
+            organization=data.get("organization") or data.get("org_slug", ""),
+            status=data.get("status", ""),
+            created_at=cls._parse_datetime(data.get("created_at")),
+            updated_at=cls._parse_datetime(data.get("updated_at")),
+            bucket_name=data.get("bucket_name"),
+            primary_region=data.get("primary_region"),
+            url=data.get("url"),
+            url_settings=cls._parse_url_settings(data.get("url_settings")),
+            version=data.get("version"),
+            environment_version=data.get("environment_version"),
+            labels=data.get("labels") or [],
+            last_running_at=cls._parse_datetime(data.get("last_running_at")),
+            last_warming_at=cls._parse_datetime(data.get("last_warming_at")),
+        )
+
     def sprite(self, name: str) -> "Sprite":
         """
         Get a handle to a sprite (doesn't create it on the server).
@@ -99,7 +142,11 @@ class SpritesClient:
     def create_sprite(
         self,
         name: str,
-        config: Optional[SpriteConfig] = None
+        config: Optional[SpriteConfig] = None,
+        url_settings: Optional[URLSettings] = None,
+        labels: Optional[List[str]] = None,
+        wait_for_capacity: bool = False,
+        runtime: Optional[str] = None,
     ) -> "Sprite":
         """
         Create a new sprite.
@@ -107,6 +154,10 @@ class SpritesClient:
         Args:
             name: Sprite name
             config: Optional configuration
+            url_settings: Optional URL access settings
+            labels: Optional labels to attach to the sprite
+            wait_for_capacity: Wait until capacity is available before returning
+            runtime: Optional runtime variant ("default" or "dev")
 
         Returns:
             Created Sprite instance
@@ -123,6 +174,19 @@ class SpritesClient:
                     "storage_gb": config.storage_gb,
                 }.items() if v is not None
             }
+        if url_settings:
+            request["url_settings"] = {
+                k: v for k, v in {
+                    "auth": url_settings.auth,
+                    "private_access": url_settings.private_access,
+                }.items() if v is not None
+            }
+        if labels is not None:
+            request["labels"] = labels
+        if wait_for_capacity:
+            request["wait_for_capacity"] = True
+        if runtime is not None:
+            request["runtime"] = runtime
 
         try:
             response = self._client.post(
@@ -136,7 +200,9 @@ class SpritesClient:
 
         self._handle_response(response, "create sprite")
         result = response.json()
-        return Sprite(result["name"], self)
+        sprite = Sprite(result["name"], self)
+        sprite._update_from_info(result)
+        return sprite
 
     def get_sprite(self, name: str) -> "Sprite":
         """
@@ -152,7 +218,7 @@ class SpritesClient:
 
         try:
             response = self._client.get(
-                f"{self.base_url}/v1/sprites/{name}",
+                self._sprite_url(name),
                 headers=self._headers(),
             )
         except httpx.RequestError as e:
@@ -182,6 +248,8 @@ class SpritesClient:
                 params["continuation_token"] = options.continuation_token
             if options.prefix:
                 params["prefix"] = options.prefix
+            if options.bulk_load:
+                params["bulk_load"] = "true"
 
         try:
             response = self._client.get(
@@ -195,21 +263,15 @@ class SpritesClient:
         self._handle_response(response, "list sprites")
         data = response.json()
 
-        sprites = []
-        for s in data.get("sprites", []):
-            sprites.append(SpriteInfo(
-                id=s.get("id", ""),
-                name=s.get("name", ""),
-                organization=s.get("organization", ""),
-                status=s.get("status", ""),
-                url=s.get("url"),
-                primary_region=s.get("primary_region"),
-            ))
+        sprites = [self._parse_sprite_info(s) for s in data.get("sprites", [])]
 
         return SpriteList(
             sprites=sprites,
-            has_more=data.get("hasMore", False),
-            next_continuation_token=data.get("nextContinuationToken"),
+            has_more=data.get("has_more", False),
+            next_continuation_token=data.get("next_continuation_token"),
+            running=data.get("running", 0),
+            warm=data.get("warm", 0),
+            cold=data.get("cold", 0),
         )
 
     def list_all_sprites(self, prefix: Optional[str] = None) -> List["Sprite"]:
@@ -244,23 +306,34 @@ class SpritesClient:
 
         return all_sprites
 
-    def delete_sprite(self, name: str) -> None:
+    def destroy_sprite(self, name: str) -> None:
         """
-        Delete a sprite.
+        Destroy a sprite.
 
         Args:
             name: Sprite name
         """
         try:
             response = self._client.delete(
-                f"{self.base_url}/v1/sprites/{name}",
+                self._sprite_url(name),
                 headers=self._headers(),
             )
         except httpx.RequestError as e:
             raise NetworkError(f"Network error deleting sprite: {e}")
 
         if response.status_code != 204:
-            self._handle_response(response, f"delete sprite '{name}'")
+            self._handle_response(response, f"destroy sprite '{name}'")
+
+    def delete_sprite(self, name: str) -> None:
+        """
+        Delete a sprite.
+
+        This is an alias for destroy_sprite(), named after the HTTP DELETE method.
+
+        Args:
+            name: Sprite name
+        """
+        self.destroy_sprite(name)
 
     def upgrade_sprite(self, name: str) -> None:
         """
@@ -271,14 +344,14 @@ class SpritesClient:
         """
         try:
             response = self._client.post(
-                f"{self.base_url}/v1/sprites/{name}/upgrade",
+                f"{self._sprite_url(name)}/upgrade",
                 headers=self._headers(),
                 timeout=60.0,
             )
         except httpx.RequestError as e:
             raise NetworkError(f"Network error upgrading sprite: {e}")
 
-        if response.status_code != 204:
+        if response.status_code not in (200, 204):
             self._handle_response(response, f"upgrade sprite '{name}'")
 
     def update_url_settings(self, name: str, settings: URLSettings) -> None:
@@ -291,14 +364,68 @@ class SpritesClient:
         """
         try:
             response = self._client.put(
-                f"{self.base_url}/v1/sprites/{name}",
+                self._sprite_url(name),
                 headers=self._headers(),
-                json={"url_settings": {"auth": settings.auth}},
+                json={
+                    "url_settings": {
+                        k: v for k, v in {
+                            "auth": settings.auth,
+                            "private_access": settings.private_access,
+                        }.items() if v is not None
+                    }
+                },
             )
         except httpx.RequestError as e:
             raise NetworkError(f"Network error updating URL settings: {e}")
 
         self._handle_response(response, f"update URL settings for '{name}'")
+
+    def update_sprite(
+        self,
+        name: str,
+        *,
+        url_settings: Optional[URLSettings] = None,
+        labels: Optional[List[str]] = None,
+    ) -> "Sprite":
+        """
+        Update mutable sprite settings.
+
+        Args:
+            name: Sprite name
+            url_settings: Optional URL access settings
+            labels: Optional replacement labels
+
+        Returns:
+            Updated Sprite instance.
+        """
+        if url_settings is None and labels is None:
+            raise ValueError("url_settings or labels is required")
+
+        body: Dict[str, Any] = {}
+        if url_settings is not None:
+            body["url_settings"] = {
+                k: v for k, v in {
+                    "auth": url_settings.auth,
+                    "private_access": url_settings.private_access,
+                }.items() if v is not None
+            }
+        if labels is not None:
+            body["labels"] = labels
+
+        try:
+            response = self._client.put(
+                self._sprite_url(name),
+                headers=self._headers(),
+                json=body,
+            )
+        except httpx.RequestError as e:
+            raise NetworkError(f"Network error updating sprite: {e}")
+
+        self._handle_response(response, f"update sprite '{name}'")
+        info = response.json()
+        sprite = self.sprite(info.get("name", name))
+        sprite._update_from_info(info)
+        return sprite
 
     @staticmethod
     def create_token(

--- a/src/sprites/control.py
+++ b/src/sprites/control.py
@@ -10,6 +10,8 @@ from urllib.parse import urlencode
 import websockets
 from websockets.exceptions import ConnectionClosed
 
+from sprites._utils import quote_path_segment, websocket_base_url
+
 if TYPE_CHECKING:
     from .sprite import Sprite
 
@@ -217,14 +219,9 @@ class ControlConnection:
         if self.ws is not None:
             raise RuntimeError("Already connected")
 
-        # Build WebSocket URL
-        base_url = self.sprite.client.base_url
-        if base_url.startswith("https"):
-            base_url = "wss" + base_url[5:]
-        elif base_url.startswith("http"):
-            base_url = "ws" + base_url[4:]
-
-        url = f"{base_url}/v1/sprites/{self.sprite.name}/control"
+        base_url = websocket_base_url(self.sprite.client.base_url)
+        sprite_name = quote_path_segment(self.sprite.name)
+        url = f"{base_url}/v1/sprites/{sprite_name}/control"
         headers = {"Authorization": f"Bearer {self.sprite.client.token}"}
 
         self.ws = await websockets.connect(

--- a/src/sprites/exec.py
+++ b/src/sprites/exec.py
@@ -176,12 +176,9 @@ class Cmd:
 
         if self.timeout is not None and self.timeout > 0:
             try:
-                async with asyncio.timeout(self.timeout):
-                    return await run_ws_command(self)
+                return await asyncio.wait_for(run_ws_command(self), timeout=self.timeout)
             except asyncio.TimeoutError:
-                raise TimeoutError(
-                    f"command timed out after {self.timeout}s", timeout=self.timeout
-                ) from None
+                raise TimeoutError(f"command timed out after {self.timeout}s") from None
         else:
             return await run_ws_command(self)
 

--- a/src/sprites/filesystem.py
+++ b/src/sprites/filesystem.py
@@ -21,10 +21,10 @@ from __future__ import annotations
 import posixpath
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
-from urllib.parse import quote
 import httpx
 
 from .types import DirEntry, FileStat
+from ._utils import sprite_base_url
 from .exceptions import (
     FilesystemError,
     FileNotFoundError_,
@@ -225,8 +225,10 @@ class SpritePath:
 
     def _build_url(self, endpoint: str) -> str:
         """Build full URL for filesystem endpoint."""
-        sprite_name = quote(self._fs._sprite.name, safe="")
-        return f"{self._fs._sprite.client.base_url}/v1/sprites/{sprite_name}/fs{endpoint}"
+        return (
+            f"{sprite_base_url(self._fs._sprite.client.base_url, self._fs._sprite.name)}"
+            f"/fs{endpoint}"
+        )
 
     def _headers(self) -> Dict[str, str]:
         """Get default headers with authorization."""

--- a/src/sprites/filesystem.py
+++ b/src/sprites/filesystem.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import posixpath
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
+from urllib.parse import quote
 import httpx
 
 from .types import DirEntry, FileStat
@@ -224,7 +225,8 @@ class SpritePath:
 
     def _build_url(self, endpoint: str) -> str:
         """Build full URL for filesystem endpoint."""
-        return f"{self._fs._sprite.client.base_url}/v1/sprites/{self._fs._sprite.name}/fs{endpoint}"
+        sprite_name = quote(self._fs._sprite.name, safe="")
+        return f"{self._fs._sprite.client.base_url}/v1/sprites/{sprite_name}/fs{endpoint}"
 
     def _headers(self) -> Dict[str, str]:
         """Get default headers with authorization."""

--- a/src/sprites/policy.py
+++ b/src/sprites/policy.py
@@ -3,19 +3,15 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote
 
 import httpx
 
 from sprites.exceptions import APIError
 from sprites.types import NetworkPolicy, PolicyRule
+from sprites._utils import sprite_base_url
 
 if TYPE_CHECKING:
     from sprites.sprite import Sprite
-
-
-def _sprite_base_url(sprite: Sprite) -> str:
-    return f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
 
 
 def get_network_policy(sprite: Sprite) -> NetworkPolicy:
@@ -30,7 +26,7 @@ def get_network_policy(sprite: Sprite) -> NetworkPolicy:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{_sprite_base_url(sprite)}/policy/network"
+    url = f"{sprite_base_url(sprite.client.base_url, sprite.name)}/policy/network"
 
     try:
         response = sprite.client.http_client.get(url)
@@ -67,7 +63,7 @@ def update_network_policy(sprite: Sprite, policy: NetworkPolicy) -> None:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{_sprite_base_url(sprite)}/policy/network"
+    url = f"{sprite_base_url(sprite.client.base_url, sprite.name)}/policy/network"
 
     # Convert policy to dict
     payload: dict[str, Any] = {

--- a/src/sprites/policy.py
+++ b/src/sprites/policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 import httpx
 
@@ -11,6 +12,10 @@ from sprites.types import NetworkPolicy, PolicyRule
 
 if TYPE_CHECKING:
     from sprites.sprite import Sprite
+
+
+def _sprite_base_url(sprite: Sprite) -> str:
+    return f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
 
 
 def get_network_policy(sprite: Sprite) -> NetworkPolicy:
@@ -25,7 +30,7 @@ def get_network_policy(sprite: Sprite) -> NetworkPolicy:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/policy/network"
+    url = f"{_sprite_base_url(sprite)}/policy/network"
 
     try:
         response = sprite.client.http_client.get(url)
@@ -62,7 +67,7 @@ def update_network_policy(sprite: Sprite, policy: NetworkPolicy) -> None:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/policy/network"
+    url = f"{_sprite_base_url(sprite)}/policy/network"
 
     # Convert policy to dict
     payload: dict[str, Any] = {

--- a/src/sprites/services.py
+++ b/src/sprites/services.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from typing import TYPE_CHECKING, Iterator, Optional
+from urllib.parse import quote
 
 import httpx
 
 from sprites.exceptions import APIError
-from sprites.types import Service, ServiceLogEvent, ServiceState, ServiceWithState
+from sprites.types import ServiceLogEvent, ServiceState, ServiceWithState
 
 if TYPE_CHECKING:
     from sprites.sprite import Sprite
@@ -61,16 +62,6 @@ class ServiceStream:
 
 def _parse_service_with_state(data: dict) -> ServiceWithState:
     """Parse a service with state from API response."""
-    # Parse service definition
-    service = Service(
-        name=data.get("name", ""),
-        cmd=data.get("cmd", ""),
-        args=data.get("args", []),
-        needs=data.get("needs", []),
-        http_port=data.get("http_port"),
-    )
-
-    # Parse state if present
     state = None
     state_data = data.get("state")
     if state_data:
@@ -100,7 +91,14 @@ def _parse_service_with_state(data: dict) -> ServiceWithState:
             restart_count=state_data.get("restart_count", 0),
         )
 
-    return ServiceWithState(service=service, state=state)
+    return ServiceWithState(
+        name=data.get("name", ""),
+        cmd=data.get("cmd", ""),
+        args=data.get("args", []),
+        needs=data.get("needs", []),
+        http_port=data.get("http_port"),
+        state=state,
+    )
 
 
 def _parse_stream_response(response_text: str) -> list[ServiceLogEvent]:
@@ -136,7 +134,7 @@ def list_services(sprite: Sprite) -> list[ServiceWithState]:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/services"
+    url = f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}/services"
 
     try:
         response = sprite.client.http_client.get(url)
@@ -151,6 +149,8 @@ def list_services(sprite: Sprite) -> list[ServiceWithState]:
         )
 
     data = response.json()
+    if isinstance(data, dict):
+        data = data.get("services", [])
     return [_parse_service_with_state(s) for s in data]
 
 
@@ -167,7 +167,10 @@ def get_service(sprite: Sprite, name: str) -> ServiceWithState:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/services/{name}"
+    url = (
+        f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
+        f"/services/{quote(name, safe='')}"
+    )
 
     try:
         response = sprite.client.http_client.get(url)
@@ -213,7 +216,10 @@ def create_service(
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/services/{name}"
+    url = (
+        f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
+        f"/services/{quote(name, safe='')}"
+    )
     if duration:
         url += f"?duration={duration}s"
 
@@ -261,7 +267,10 @@ def delete_service(sprite: Sprite, name: str) -> None:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/services/{name}"
+    url = (
+        f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
+        f"/services/{quote(name, safe='')}"
+    )
 
     try:
         response = sprite.client.http_client.delete(url)
@@ -304,7 +313,10 @@ def start_service(
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/services/{name}/start"
+    url = (
+        f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
+        f"/services/{quote(name, safe='')}/start"
+    )
     if duration:
         url += f"?duration={duration}s"
 
@@ -348,7 +360,10 @@ def stop_service(
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/services/{name}/stop"
+    url = (
+        f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
+        f"/services/{quote(name, safe='')}/stop"
+    )
     if timeout:
         url += f"?timeout={timeout}s"
 
@@ -392,7 +407,7 @@ def signal_service(sprite: Sprite, name: str, signal: str) -> None:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/services/signal"
+    url = f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}/services/signal"
 
     payload = {
         "name": name,

--- a/src/sprites/services.py
+++ b/src/sprites/services.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from typing import TYPE_CHECKING, Iterator, Optional
-from urllib.parse import quote
 
 import httpx
 
 from sprites.exceptions import APIError
 from sprites.types import ServiceLogEvent, ServiceState, ServiceWithState
+from sprites._utils import quote_path_segment, sprite_base_url
 
 if TYPE_CHECKING:
     from sprites.sprite import Sprite
@@ -122,6 +122,14 @@ def _parse_stream_response(response_text: str) -> list[ServiceLogEvent]:
     return messages
 
 
+def _sprite_services_url(sprite: Sprite) -> str:
+    return f"{sprite_base_url(sprite.client.base_url, sprite.name)}/services"
+
+
+def _service_url(sprite: Sprite, name: str) -> str:
+    return f"{_sprite_services_url(sprite)}/{quote_path_segment(name)}"
+
+
 def list_services(sprite: Sprite) -> list[ServiceWithState]:
     """List all services for a sprite.
 
@@ -134,7 +142,7 @@ def list_services(sprite: Sprite) -> list[ServiceWithState]:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}/services"
+    url = _sprite_services_url(sprite)
 
     try:
         response = sprite.client.http_client.get(url)
@@ -167,10 +175,7 @@ def get_service(sprite: Sprite, name: str) -> ServiceWithState:
     Raises:
         APIError: If the API call fails.
     """
-    url = (
-        f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
-        f"/services/{quote(name, safe='')}"
-    )
+    url = _service_url(sprite, name)
 
     try:
         response = sprite.client.http_client.get(url)
@@ -216,10 +221,7 @@ def create_service(
     Raises:
         APIError: If the API call fails.
     """
-    url = (
-        f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
-        f"/services/{quote(name, safe='')}"
-    )
+    url = _service_url(sprite, name)
     if duration:
         url += f"?duration={duration}s"
 
@@ -267,10 +269,7 @@ def delete_service(sprite: Sprite, name: str) -> None:
     Raises:
         APIError: If the API call fails.
     """
-    url = (
-        f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
-        f"/services/{quote(name, safe='')}"
-    )
+    url = _service_url(sprite, name)
 
     try:
         response = sprite.client.http_client.delete(url)
@@ -313,10 +312,7 @@ def start_service(
     Raises:
         APIError: If the API call fails.
     """
-    url = (
-        f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
-        f"/services/{quote(name, safe='')}/start"
-    )
+    url = f"{_service_url(sprite, name)}/start"
     if duration:
         url += f"?duration={duration}s"
 
@@ -360,10 +356,7 @@ def stop_service(
     Raises:
         APIError: If the API call fails.
     """
-    url = (
-        f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
-        f"/services/{quote(name, safe='')}/stop"
-    )
+    url = f"{_service_url(sprite, name)}/stop"
     if timeout:
         url += f"?timeout={timeout}s"
 
@@ -407,7 +400,7 @@ def signal_service(sprite: Sprite, name: str, signal: str) -> None:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}/services/signal"
+    url = f"{_sprite_services_url(sprite)}/signal"
 
     payload = {
         "name": name,

--- a/src/sprites/session.py
+++ b/src/sprites/session.py
@@ -5,19 +5,15 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from typing import TYPE_CHECKING, Iterator
-from urllib.parse import quote
 
 import httpx
 
 from sprites.exceptions import APIError
 from sprites.types import Session, StreamMessage
+from sprites._utils import quote_path_segment, sprite_base_url
 
 if TYPE_CHECKING:
     from sprites.sprite import Sprite
-
-
-def _sprite_base_url(sprite: Sprite) -> str:
-    return f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
 
 
 class KillStream:
@@ -76,7 +72,7 @@ def list_sessions(sprite: Sprite) -> list[Session]:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{_sprite_base_url(sprite)}/exec"
+    url = f"{sprite_base_url(sprite.client.base_url, sprite.name)}/exec"
 
     try:
         response = sprite.client.http_client.get(url)
@@ -148,7 +144,10 @@ def kill_session(
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{_sprite_base_url(sprite)}/exec/{quote(session_id, safe='')}/kill"
+    url = (
+        f"{sprite_base_url(sprite.client.base_url, sprite.name)}"
+        f"/exec/{quote_path_segment(session_id)}/kill"
+    )
 
     payload = {
         "signal": signal,

--- a/src/sprites/session.py
+++ b/src/sprites/session.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from typing import TYPE_CHECKING, Iterator
+from urllib.parse import quote
 
 import httpx
 
@@ -13,6 +14,10 @@ from sprites.types import Session, StreamMessage
 
 if TYPE_CHECKING:
     from sprites.sprite import Sprite
+
+
+def _sprite_base_url(sprite: Sprite) -> str:
+    return f"{sprite.client.base_url}/v1/sprites/{quote(sprite.name, safe='')}"
 
 
 class KillStream:
@@ -71,7 +76,7 @@ def list_sessions(sprite: Sprite) -> list[Session]:
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/exec"
+    url = f"{_sprite_base_url(sprite)}/exec"
 
     try:
         response = sprite.client.http_client.get(url)
@@ -143,7 +148,7 @@ def kill_session(
     Raises:
         APIError: If the API call fails.
     """
-    url = f"{sprite.client.base_url}/v1/sprites/{sprite.name}/exec/{session_id}/kill"
+    url = f"{_sprite_base_url(sprite)}/exec/{quote(session_id, safe='')}/kill"
 
     payload = {
         "signal": signal,

--- a/src/sprites/sprite.py
+++ b/src/sprites/sprite.py
@@ -4,7 +4,6 @@ Sprite class representing a sprite instance
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from datetime import datetime
-from urllib.parse import quote
 import httpx
 
 from .types import (
@@ -21,6 +20,7 @@ from .exceptions import (
     NetworkError,
     NotFoundError,
 )
+from ._utils import parse_sprite_info, quote_path_segment, sprite_base_url
 
 if TYPE_CHECKING:
     from .client import SpritesClient
@@ -60,41 +60,28 @@ class Sprite:
         self.version: Optional[str] = None
         self.environment_version: Optional[str] = None
         self.labels: List[str] = []
+        self.last_running_at: Optional[datetime] = None
+        self.last_warming_at: Optional[datetime] = None
 
     def _update_from_info(self, info: Dict[str, Any]) -> None:
         """Update sprite properties from API response."""
-        self.id = info.get("id")
-        self.organization_name = info.get("organization")
-        self.status = info.get("status")
-        self.url = info.get("url")
-        self.primary_region = info.get("primary_region")
-        self.bucket_name = info.get("bucket_name")
-        self.version = info.get("version")
-        self.environment_version = info.get("environment_version")
-        self.labels = info.get("labels") or []
-
-        if isinstance(info.get("url_settings"), dict):
-            url_settings = info["url_settings"]
-            self.url_settings = URLSettings(
-                auth=url_settings.get("auth"),
-                private_access=url_settings.get("private_access"),
-            )
-
-        if "created_at" in info and info["created_at"]:
-            try:
-                self.created_at = datetime.fromisoformat(
-                    info["created_at"].replace("Z", "+00:00")
-                )
-            except (ValueError, AttributeError):
-                pass
-
-        if "updated_at" in info and info["updated_at"]:
-            try:
-                self.updated_at = datetime.fromisoformat(
-                    info["updated_at"].replace("Z", "+00:00")
-                )
-            except (ValueError, AttributeError):
-                pass
+        parsed = parse_sprite_info(info)
+        self.id = parsed.id
+        self.organization_name = parsed.organization
+        self.status = parsed.status
+        self.config = parsed.config
+        self.environment = parsed.environment
+        self.created_at = parsed.created_at
+        self.updated_at = parsed.updated_at
+        self.url = parsed.url
+        self.primary_region = parsed.primary_region
+        self.bucket_name = parsed.bucket_name
+        self.url_settings = parsed.url_settings
+        self.version = parsed.version
+        self.environment_version = parsed.environment_version
+        self.labels = parsed.labels
+        self.last_running_at = parsed.last_running_at
+        self.last_warming_at = parsed.last_warming_at
 
     def _headers(self) -> Dict[str, str]:
         """Get default headers with authorization."""
@@ -105,7 +92,7 @@ class Sprite:
 
     def _base_url(self) -> str:
         """Get sprite-specific base URL."""
-        return f"{self.client.base_url}/v1/sprites/{quote(self.name, safe='')}"
+        return sprite_base_url(self.client.base_url, self.name)
 
     # ========== Filesystem API ==========
 
@@ -140,6 +127,9 @@ class Sprite:
         """
         Update URL authentication settings.
 
+        This is a compatibility convenience for updating only URL settings.
+        Prefer update(...) when changing mutable sprite fields.
+
         Args:
             settings: URL settings with auth: "public" for no auth, "sprite" for authenticated
         """
@@ -151,7 +141,7 @@ class Sprite:
         url_settings: Optional[URLSettings] = None,
         labels: Optional[List[str]] = None,
     ) -> "Sprite":
-        """Update mutable settings for this sprite and return the refreshed sprite."""
+        """Partially update mutable settings and return the refreshed sprite."""
         return self.client.update_sprite(
             self.name,
             url_settings=url_settings,
@@ -280,7 +270,7 @@ class Sprite:
         """
         try:
             response = self.client._client.get(
-                f"{self._base_url()}/checkpoints/{quote(checkpoint_id, safe='')}",
+                f"{self._base_url()}/checkpoints/{quote_path_segment(checkpoint_id)}",
                 headers=self._headers(),
             )
         except httpx.RequestError as e:
@@ -397,7 +387,10 @@ class Sprite:
         tty_rows: int = 24,
         tty_cols: int = 80,
     ):
-        """Run a command on this sprite, mirroring subprocess.run."""
+        """Run a command on this sprite, mirroring subprocess.run.
+
+        Use command(...) when you need streaming stdin/stdout/stderr handles.
+        """
         from .exec import run
 
         return run(
@@ -470,7 +463,7 @@ class Sprite:
         """
         try:
             response = self.client._client.delete(
-                f"{self._base_url()}/services/{quote(service_name, safe='')}",
+                f"{self._base_url()}/services/{quote_path_segment(service_name)}",
                 headers=self._headers(),
             )
         except httpx.RequestError as e:

--- a/src/sprites/sprite.py
+++ b/src/sprites/sprite.py
@@ -4,6 +4,7 @@ Sprite class representing a sprite instance
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from datetime import datetime
+from urllib.parse import quote
 import httpx
 
 from .types import (
@@ -14,8 +15,6 @@ from .types import (
     NetworkPolicy,
     PolicyRule,
     ServiceWithState,
-    ServiceRequest,
-    ServiceState,
 )
 from .exceptions import (
     SpriteError,
@@ -58,6 +57,9 @@ class Sprite:
         self.primary_region: Optional[str] = None
         self.url: Optional[str] = None
         self.url_settings: Optional[URLSettings] = None
+        self.version: Optional[str] = None
+        self.environment_version: Optional[str] = None
+        self.labels: List[str] = []
 
     def _update_from_info(self, info: Dict[str, Any]) -> None:
         """Update sprite properties from API response."""
@@ -67,6 +69,16 @@ class Sprite:
         self.url = info.get("url")
         self.primary_region = info.get("primary_region")
         self.bucket_name = info.get("bucket_name")
+        self.version = info.get("version")
+        self.environment_version = info.get("environment_version")
+        self.labels = info.get("labels") or []
+
+        if isinstance(info.get("url_settings"), dict):
+            url_settings = info["url_settings"]
+            self.url_settings = URLSettings(
+                auth=url_settings.get("auth"),
+                private_access=url_settings.get("private_access"),
+            )
 
         if "created_at" in info and info["created_at"]:
             try:
@@ -93,7 +105,7 @@ class Sprite:
 
     def _base_url(self) -> str:
         """Get sprite-specific base URL."""
-        return f"{self.client.base_url}/v1/sprites/{self.name}"
+        return f"{self.client.base_url}/v1/sprites/{quote(self.name, safe='')}"
 
     # ========== Filesystem API ==========
 
@@ -112,13 +124,13 @@ class Sprite:
 
     # ========== Lifecycle API ==========
 
-    def delete(self) -> None:
-        """Delete this sprite."""
-        self.client.delete_sprite(self.name)
-
     def destroy(self) -> None:
-        """Alias for delete()."""
-        self.delete()
+        """Destroy this sprite."""
+        self.client.destroy_sprite(self.name)
+
+    def delete(self) -> None:
+        """Alias for destroy(), named after the HTTP DELETE method."""
+        self.destroy()
 
     def upgrade(self) -> None:
         """Upgrade this sprite to the latest version."""
@@ -132,6 +144,19 @@ class Sprite:
             settings: URL settings with auth: "public" for no auth, "sprite" for authenticated
         """
         self.client.update_url_settings(self.name, settings)
+
+    def update(
+        self,
+        *,
+        url_settings: Optional[URLSettings] = None,
+        labels: Optional[List[str]] = None,
+    ) -> "Sprite":
+        """Update mutable settings for this sprite and return the refreshed sprite."""
+        return self.client.update_sprite(
+            self.name,
+            url_settings=url_settings,
+            labels=labels,
+        )
 
     # ========== Sessions API ==========
 
@@ -255,7 +280,7 @@ class Sprite:
         """
         try:
             response = self.client._client.get(
-                f"{self._base_url()}/checkpoints/{checkpoint_id}",
+                f"{self._base_url()}/checkpoints/{quote(checkpoint_id, safe='')}",
                 headers=self._headers(),
             )
         except httpx.RequestError as e:
@@ -320,6 +345,12 @@ class Sprite:
         env: Optional[Dict[str, str]] = None,
         cwd: Optional[str] = None,
         timeout: Optional[float] = None,
+        stdin: Any = None,
+        stdout: Any = None,
+        stderr: Any = None,
+        tty: bool = False,
+        tty_rows: int = 24,
+        tty_cols: int = 80,
     ):
         """
         Create a command to run on this sprite.
@@ -329,6 +360,12 @@ class Sprite:
             env: Environment variables
             cwd: Working directory
             timeout: Command timeout in seconds
+            stdin: Optional file-like stdin source
+            stdout: Optional file-like stdout sink
+            stderr: Optional file-like stderr sink
+            tty: Enable TTY mode
+            tty_rows: Terminal height
+            tty_cols: Terminal width
 
         Returns:
             Cmd object for executing the command
@@ -339,7 +376,41 @@ class Sprite:
             args=list(args),
             env=env,
             cwd=cwd,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            tty=tty,
+            tty_rows=tty_rows,
+            tty_cols=tty_cols,
             timeout=timeout,
+        )
+
+    def run(
+        self,
+        *args: str,
+        capture_output: bool = False,
+        timeout: Optional[float] = None,
+        check: bool = False,
+        env: Optional[Dict[str, str]] = None,
+        cwd: Optional[str] = None,
+        tty: bool = False,
+        tty_rows: int = 24,
+        tty_cols: int = 80,
+    ):
+        """Run a command on this sprite, mirroring subprocess.run."""
+        from .exec import run
+
+        return run(
+            self,
+            *args,
+            capture_output=capture_output,
+            timeout=timeout,
+            check=check,
+            env=env,
+            cwd=cwd,
+            tty=tty,
+            tty_rows=tty_rows,
+            tty_cols=tty_cols,
         )
 
     def attach_session(
@@ -374,45 +445,8 @@ class Sprite:
         Returns:
             List of ServiceWithState objects
         """
-        try:
-            response = self.client._client.get(
-                f"{self._base_url()}/services",
-                headers=self._headers(),
-            )
-        except httpx.RequestError as e:
-            raise NetworkError(f"Network error listing services: {e}")
-
-        if not response.is_success:
-            raise SpriteError(
-                f"Failed to list services (status {response.status_code}): {response.text}"
-            )
-
-        data = response.json()
-        services: List[ServiceWithState] = []
-
-        for s in data:
-            state = None
-            if s.get("state"):
-                state = ServiceState(
-                    name=s["state"].get("name", ""),
-                    status=s["state"].get("status", "stopped"),
-                    pid=s["state"].get("pid"),
-                    started_at=s["state"].get("started_at"),
-                    error=s["state"].get("error"),
-                    restart_count=s["state"].get("restart_count", 0),
-                    next_restart_at=s["state"].get("next_restart_at"),
-                )
-
-            services.append(ServiceWithState(
-                name=s.get("name", ""),
-                cmd=s.get("cmd", ""),
-                args=s.get("args", []),
-                needs=s.get("needs", []),
-                http_port=s.get("http_port"),
-                state=state,
-            ))
-
-        return services
+        from .services import list_services
+        return list_services(self)
 
     def get_service(self, service_name: str) -> ServiceWithState:
         """
@@ -424,43 +458,8 @@ class Sprite:
         Returns:
             ServiceWithState object
         """
-        try:
-            response = self.client._client.get(
-                f"{self._base_url()}/services/{service_name}",
-                headers=self._headers(),
-            )
-        except httpx.RequestError as e:
-            raise NetworkError(f"Network error getting service: {e}")
-
-        if response.status_code == 404:
-            raise NotFoundError(f"Service not found: {service_name}")
-
-        if not response.is_success:
-            raise SpriteError(
-                f"Failed to get service (status {response.status_code}): {response.text}"
-            )
-
-        s = response.json()
-        state = None
-        if s.get("state"):
-            state = ServiceState(
-                name=s["state"].get("name", ""),
-                status=s["state"].get("status", "stopped"),
-                pid=s["state"].get("pid"),
-                started_at=s["state"].get("started_at"),
-                error=s["state"].get("error"),
-                restart_count=s["state"].get("restart_count", 0),
-                next_restart_at=s["state"].get("next_restart_at"),
-            )
-
-        return ServiceWithState(
-            name=s.get("name", ""),
-            cmd=s.get("cmd", ""),
-            args=s.get("args", []),
-            needs=s.get("needs", []),
-            http_port=s.get("http_port"),
-            state=state,
-        )
+        from .services import get_service
+        return get_service(self, service_name)
 
     def delete_service(self, service_name: str) -> None:
         """
@@ -471,7 +470,7 @@ class Sprite:
         """
         try:
             response = self.client._client.delete(
-                f"{self._base_url()}/services/{service_name}",
+                f"{self._base_url()}/services/{quote(service_name, safe='')}",
                 headers=self._headers(),
             )
         except httpx.RequestError as e:
@@ -481,6 +480,34 @@ class Sprite:
             raise SpriteError(
                 f"Failed to delete service (status {response.status_code}): {response.text}"
             )
+
+    def create_service(
+        self,
+        service_name: str,
+        cmd: str,
+        args: Optional[List[str]] = None,
+        needs: Optional[List[str]] = None,
+        http_port: Optional[int] = None,
+        duration: Optional[float] = None,
+    ):
+        """Create or update a service and return its log stream."""
+        from .services import create_service
+        return create_service(self, service_name, cmd, args, needs, http_port, duration)
+
+    def start_service(self, service_name: str, duration: Optional[float] = None):
+        """Start a service and return its log stream."""
+        from .services import start_service
+        return start_service(self, service_name, duration)
+
+    def stop_service(self, service_name: str, timeout: Optional[float] = None):
+        """Stop a service and return its log stream."""
+        from .services import stop_service
+        return stop_service(self, service_name, timeout)
+
+    def signal_service(self, service_name: str, signal: str) -> None:
+        """Send a signal to a running service."""
+        from .services import signal_service
+        signal_service(self, service_name, signal)
 
     # ========== Policy API ==========
 

--- a/src/sprites/types.py
+++ b/src/sprites/types.py
@@ -4,7 +4,6 @@ Type definitions for the Sprites SDK
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
 from typing import Any, Dict, List, Optional
 
 
@@ -19,6 +18,7 @@ class ClientOptions:
 class URLSettings:
     """URL authentication settings."""
     auth: Optional[str] = None  # "public" or "sprite"
+    private_access: Optional[str] = None
 
 
 @dataclass
@@ -73,6 +73,11 @@ class SpriteInfo:
     primary_region: Optional[str] = None
     url: Optional[str] = None
     url_settings: Optional[URLSettings] = None
+    version: Optional[str] = None
+    environment_version: Optional[str] = None
+    labels: List[str] = field(default_factory=list)
+    last_running_at: Optional[datetime] = None
+    last_warming_at: Optional[datetime] = None
 
 
 @dataclass
@@ -81,6 +86,7 @@ class ListOptions:
     prefix: Optional[str] = None
     max_results: Optional[int] = None
     continuation_token: Optional[str] = None
+    bulk_load: bool = False
 
 
 @dataclass
@@ -89,6 +95,9 @@ class SpriteList:
     sprites: List[SpriteInfo]
     has_more: bool
     next_continuation_token: Optional[str] = None
+    running: int = 0
+    warm: int = 0
+    cold: int = 0
 
 
 @dataclass
@@ -145,10 +154,10 @@ class ServiceState:
     name: str
     status: str  # "stopped", "starting", "running", "stopping", "failed"
     pid: Optional[int] = None
-    started_at: Optional[str] = None
+    started_at: Optional[datetime] = None
     error: Optional[str] = None
     restart_count: int = 0
-    next_restart_at: Optional[str] = None
+    next_restart_at: Optional[datetime] = None
 
 
 @dataclass

--- a/src/sprites/websocket.py
+++ b/src/sprites/websocket.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Callable
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 
 import websockets
 from websockets.exceptions import ConnectionClosed, InvalidStatusCode, InvalidStatus
@@ -51,6 +51,7 @@ class WSCommand:
         self._stdout_buffer: bytearray = bytearray()
         self._stderr_buffer: bytearray = bytearray()
         self._io_task: asyncio.Task[None] | None = None
+        self._session_info_event = asyncio.Event()
 
     def _build_websocket_url(self) -> str:
         """Build the WebSocket URL with query parameters."""
@@ -63,10 +64,12 @@ class WSCommand:
             base_url = "ws" + base_url[4:]
 
         # Build path
+        sprite_name = quote(self.cmd.sprite.name, safe="")
         if self.cmd.session_id:
-            path = f"/v1/sprites/{self.cmd.sprite.name}/exec/{self.cmd.session_id}"
+            session_id = quote(self.cmd.session_id, safe="")
+            path = f"/v1/sprites/{sprite_name}/exec/{session_id}"
         else:
-            path = f"/v1/sprites/{self.cmd.sprite.name}/exec"
+            path = f"/v1/sprites/{sprite_name}/exec"
 
         # Build query params
         params: list[tuple[str, str]] = []
@@ -143,25 +146,8 @@ class WSCommand:
 
     async def _wait_for_session_info(self) -> None:
         """Wait for session_info message when attaching."""
-        if self.ws is None:
-            raise RuntimeError("WebSocket not connected")
-
         try:
-            async with asyncio.timeout(10):
-                async for message in self.ws:
-                    if isinstance(message, str):
-                        try:
-                            info = json.loads(message)
-                            if info.get("type") == "session_info":
-                                self.cmd.tty = info.get("tty", False)
-                                if self.text_message_handler:
-                                    self.text_message_handler(message.encode())
-                                return
-                        except json.JSONDecodeError:
-                            pass
-                        # Pass other text messages to handler
-                        if self.text_message_handler:
-                            self.text_message_handler(message.encode())
+            await asyncio.wait_for(self._session_info_event.wait(), timeout=10)
         except asyncio.TimeoutError:
             raise RuntimeError("timeout waiting for session_info") from None
 
@@ -232,9 +218,7 @@ class WSCommand:
         if self.cmd.tty:
             # TTY mode
             if isinstance(message, str):
-                # Text message - control/notification
-                if self.text_message_handler:
-                    self.text_message_handler(message.encode())
+                self._handle_text_message(message)
             else:
                 # Binary - raw terminal data
                 self._stdout_buffer.extend(message)
@@ -243,9 +227,7 @@ class WSCommand:
         else:
             # Non-TTY mode - stream-based protocol
             if isinstance(message, str):
-                # Text messages are control/notifications
-                if self.text_message_handler:
-                    self.text_message_handler(message.encode())
+                self._handle_text_message(message)
                 return
 
             if not message:
@@ -266,6 +248,19 @@ class WSCommand:
                 self.exit_code = payload[0] if payload else 0
                 # Mark as done - the connection will close and loop will exit
                 self.done = True
+
+    def _handle_text_message(self, message: str) -> None:
+        """Handle text control/notification messages."""
+        try:
+            info = json.loads(message)
+            if info.get("type") == "session_info":
+                self.cmd.tty = info.get("tty", False)
+                self._session_info_event.set()
+        except json.JSONDecodeError:
+            pass
+
+        if self.text_message_handler:
+            self.text_message_handler(message.encode())
 
     async def _copy_stdin(self) -> None:
         """Copy data from stdin to WebSocket."""

--- a/src/sprites/websocket.py
+++ b/src/sprites/websocket.py
@@ -6,12 +6,13 @@ import asyncio
 import json
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Callable
-from urllib.parse import quote, urlencode
+from urllib.parse import urlencode
 
 import websockets
 from websockets.exceptions import ConnectionClosed, InvalidStatusCode, InvalidStatus
 
 from sprites.exceptions import parse_api_error
+from sprites._utils import quote_path_segment, websocket_base_url
 
 if TYPE_CHECKING:
     from sprites.exec import Cmd
@@ -55,18 +56,12 @@ class WSCommand:
 
     def _build_websocket_url(self) -> str:
         """Build the WebSocket URL with query parameters."""
-        base_url = self.cmd.sprite.client.base_url
-
-        # Convert HTTP(S) to WS(S)
-        if base_url.startswith("https"):
-            base_url = "wss" + base_url[5:]
-        elif base_url.startswith("http"):
-            base_url = "ws" + base_url[4:]
+        base_url = websocket_base_url(self.cmd.sprite.client.base_url)
 
         # Build path
-        sprite_name = quote(self.cmd.sprite.name, safe="")
+        sprite_name = quote_path_segment(self.cmd.sprite.name)
         if self.cmd.session_id:
-            session_id = quote(self.cmd.session_id, safe="")
+            session_id = quote_path_segment(self.cmd.session_id)
             path = f"/v1/sprites/{sprite_name}/exec/{session_id}"
         else:
             path = f"/v1/sprites/{sprite_name}/exec"

--- a/test_cli/main.py
+++ b/test_cli/main.py
@@ -241,7 +241,7 @@ def cmd_destroy(client: SpritesClient, args: List[str]) -> None:
         print("Error: sprite name is required for destroy command", file=sys.stderr)
         sys.exit(1)
 
-    client.delete_sprite(args[0])
+    client.destroy_sprite(args[0])
     print(f"Destroyed sprite: {args[0]}")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,33 @@
 """Pytest configuration for Sprites SDK tests."""
 
 import os
+import sys
+from pathlib import Path
 
 import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+
+@pytest.fixture
+def make_mock_client():
+    """Create SpritesClient instances backed by an httpx MockTransport."""
+    import httpx
+
+    from sprites import SpritesClient
+
+    clients = []
+
+    def factory(handler):
+        client = SpritesClient("test-token", base_url="https://api.test")
+        client._client = httpx.Client(transport=httpx.MockTransport(handler))
+        clients.append(client)
+        return client
+
+    yield factory
+
+    for client in clients:
+        client.close()
 
 
 @pytest.fixture

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -117,6 +117,27 @@ def test_update_sprite_can_update_labels_and_url_settings() -> None:
     assert sprite.labels == ["sdk", "python"]
 
 
+def test_update_sprite_sends_only_supplied_partial_fields() -> None:
+    bodies = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(200, json={"name": "demo", **bodies[-1]})
+
+    client = make_client(handler)
+
+    labels_only = client.update_sprite("demo", labels=["sdk"])
+    settings_only = client.update_sprite("demo", url_settings=URLSettings(auth="public"))
+
+    assert bodies == [
+        {"labels": ["sdk"]},
+        {"url_settings": {"auth": "public"}},
+    ]
+    assert labels_only.labels == ["sdk"]
+    assert settings_only.url_settings is not None
+    assert settings_only.url_settings.auth == "public"
+
+
 def test_destroy_sprite_uses_delete_endpoint() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "DELETE"

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import pytest
+import httpx
+import json
+import asyncio
+
+from sprites import ListOptions, SpritesClient, URLSettings
+from sprites.exceptions import TimeoutError
+from sprites.exec import Cmd
+
+
+def make_client(handler):
+    client = SpritesClient("test-token", base_url="https://api.test")
+    client._client = httpx.Client(transport=httpx.MockTransport(handler))
+    return client
+
+
+def test_list_sprites_parses_current_snake_case_response() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["bulk_load"] == "true"
+        return httpx.Response(
+            200,
+            json={
+                "sprites": [
+                    {
+                        "id": "sprite-1",
+                        "name": "demo",
+                        "organization": "acme",
+                        "status": "running",
+                        "url": "https://demo.sprites.app",
+                        "url_settings": {"auth": "sprite", "private_access": "admins"},
+                        "version": "0.0.1",
+                        "environment_version": "0.0.2",
+                        "labels": ["sdk"],
+                        "created_at": "2026-01-12T21:24:42Z",
+                        "updated_at": "2026-01-12T21:25:42Z",
+                    }
+                ],
+                "has_more": True,
+                "next_continuation_token": "next",
+                "running": 1,
+                "warm": 2,
+                "cold": 3,
+            },
+        )
+
+    client = make_client(handler)
+
+    result = client.list_sprites(ListOptions(bulk_load=True))
+
+    assert result.has_more is True
+    assert result.next_continuation_token == "next"
+    assert (result.running, result.warm, result.cold) == (1, 2, 3)
+    sprite = result.sprites[0]
+    assert sprite.organization == "acme"
+    assert sprite.url_settings is not None
+    assert sprite.url_settings.private_access == "admins"
+    assert sprite.labels == ["sdk"]
+    assert sprite.created_at is not None
+
+
+def test_create_sprite_sends_current_optional_fields() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["url_settings"] == {"auth": "public", "private_access": "admins"}
+        assert body["labels"] == ["sdk"]
+        assert body["wait_for_capacity"] is True
+        assert body["runtime"] == "dev"
+        return httpx.Response(
+            201,
+            json={
+                "id": "sprite-1",
+                "name": "demo",
+                "organization": "acme",
+                "status": "cold",
+                "url_settings": {"auth": "public", "private_access": "admins"},
+            },
+        )
+
+    client = make_client(handler)
+
+    sprite = client.create_sprite(
+        "demo",
+        url_settings=URLSettings(auth="public", private_access="admins"),
+        labels=["sdk"],
+        wait_for_capacity=True,
+        runtime="dev",
+    )
+
+    assert sprite.name == "demo"
+    assert sprite.id == "sprite-1"
+    assert sprite.url_settings is not None
+    assert sprite.url_settings.auth == "public"
+
+
+def test_update_sprite_can_update_labels_and_url_settings() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PUT"
+        assert request.url.path == "/v1/sprites/demo"
+        body = json.loads(request.content)
+        assert body["labels"] == ["sdk", "python"]
+        assert body["url_settings"] == {"auth": "sprite"}
+        return httpx.Response(
+            200,
+            json={"name": "demo", "labels": ["sdk", "python"], "url_settings": {"auth": "sprite"}},
+        )
+
+    client = make_client(handler)
+
+    sprite = client.update_sprite(
+        "demo",
+        labels=["sdk", "python"],
+        url_settings=URLSettings(auth="sprite"),
+    )
+
+    assert sprite.labels == ["sdk", "python"]
+
+
+def test_destroy_sprite_uses_delete_endpoint() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "DELETE"
+        assert request.url.path == "/v1/sprites/demo"
+        return httpx.Response(204)
+
+    client = make_client(handler)
+
+    client.destroy_sprite("demo")
+
+
+def test_service_helpers_parse_api_array_shape() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/sprites/demo/services"
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "name": "web",
+                    "cmd": "python",
+                    "args": ["-m", "http.server"],
+                    "needs": [],
+                    "http_port": 8000,
+                    "state": {
+                        "name": "web",
+                        "status": "running",
+                        "pid": 123,
+                        "started_at": "2026-01-12T21:24:42Z",
+                        "restart_count": 1,
+                    },
+                }
+            ],
+        )
+
+    client = make_client(handler)
+
+    services = client.sprite("demo").list_services()
+
+    assert len(services) == 1
+    assert services[0].name == "web"
+    assert services[0].state is not None
+    assert services[0].state.status == "running"
+    assert services[0].state.started_at is not None
+
+
+def test_sprite_command_accepts_documented_tty_options() -> None:
+    sprite = SpritesClient("test-token").sprite("demo")
+
+    cmd = sprite.command("bash", tty=True, tty_rows=40, tty_cols=120)
+
+    assert isinstance(cmd, Cmd)
+    assert cmd.tty is True
+    assert cmd.tty_rows == 40
+    assert cmd.tty_cols == 120
+
+
+def test_command_timeout_raises_sdk_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def slow_command(_cmd: Cmd) -> int:
+        await asyncio.sleep(1)
+        return 0
+
+    monkeypatch.setattr("sprites.websocket.run_ws_command", slow_command)
+    sprite = SpritesClient("test-token").sprite("demo")
+    cmd = Cmd(sprite, ["sleep"], timeout=0.01)
+
+    with pytest.raises(TimeoutError):
+        asyncio.run(cmd._run_async())

--- a/tests/test_client_public_api.py
+++ b/tests/test_client_public_api.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from sprites import SpritesClient, URLSettings
+from sprites.exceptions import AuthenticationError, NotFoundError, SpriteError
+
+
+def test_context_manager_closes_underlying_http_client() -> None:
+    with SpritesClient("test-token", base_url="https://api.test") as client:
+        underlying = client._client
+
+    assert underlying.is_closed
+
+
+def test_sprite_returns_unfetched_handle() -> None:
+    client = SpritesClient("test-token", base_url="https://api.test")
+
+    sprite = client.sprite("demo")
+
+    assert sprite.name == "demo"
+    assert sprite.client is client
+
+
+def test_get_sprite_parses_current_fields_and_encodes_name(make_mock_client) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert str(request.url) == "https://api.test/v1/sprites/demo%20space%2Fslash"
+        return httpx.Response(
+            200,
+            json={
+                "id": "sprite-1",
+                "name": "demo space/slash",
+                "organization": "acme",
+                "status": "running",
+                "url": "https://demo.sprites.app",
+                "url_settings": {"auth": "sprite", "private_access": "admins"},
+                "version": "1.2.3",
+                "environment_version": "4.5.6",
+                "labels": ["sdk", "python"],
+                "created_at": "2026-01-12T21:24:42Z",
+                "updated_at": "2026-01-12T21:25:42Z",
+            },
+        )
+
+    client = make_mock_client(handler)
+
+    sprite = client.get_sprite("demo space/slash")
+
+    assert sprite.id == "sprite-1"
+    assert sprite.organization_name == "acme"
+    assert sprite.url_settings is not None
+    assert sprite.url_settings.private_access == "admins"
+    assert sprite.labels == ["sdk", "python"]
+    assert sprite.created_at is not None
+    assert sprite.updated_at is not None
+
+
+def test_list_all_sprites_paginates_and_applies_prefix(make_mock_client) -> None:
+    seen_params = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        params = dict(request.url.params)
+        seen_params.append(params)
+        assert request.url.path == "/v1/sprites"
+        assert params["prefix"] == "demo"
+        assert params["max_results"] == "100"
+
+        if "continuation_token" not in params:
+            return httpx.Response(
+                200,
+                json={
+                    "sprites": [{"name": "demo-1", "status": "running"}],
+                    "has_more": True,
+                    "next_continuation_token": "next-page",
+                },
+            )
+
+        assert params["continuation_token"] == "next-page"
+        return httpx.Response(
+            200,
+            json={
+                "sprites": [{"name": "demo-2", "status": "cold"}],
+                "has_more": False,
+            },
+        )
+
+    client = make_mock_client(handler)
+
+    sprites = client.list_all_sprites(prefix="demo")
+
+    assert [sprite.name for sprite in sprites] == ["demo-1", "demo-2"]
+    assert len(seen_params) == 2
+
+
+def test_delete_sprite_alias_delegates_to_destroy(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = SpritesClient("test-token", base_url="https://api.test")
+    calls = []
+
+    def destroy_sprite(name: str) -> None:
+        calls.append(name)
+
+    monkeypatch.setattr(client, "destroy_sprite", destroy_sprite)
+
+    client.delete_sprite("demo")
+
+    assert calls == ["demo"]
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_exception"),
+    [
+        (401, AuthenticationError),
+        (404, NotFoundError),
+        (500, SpriteError),
+    ],
+)
+def test_handle_response_maps_api_errors(
+    status_code: int,
+    expected_exception: type[Exception],
+) -> None:
+    client = SpritesClient("test-token", base_url="https://api.test")
+    response = httpx.Response(status_code, text="boom")
+
+    with pytest.raises(expected_exception):
+        client._handle_response(response, "test operation")
+
+
+def test_create_token_posts_fly_auth_and_invite_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_client = httpx.Client
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["auth"] = request.headers["Authorization"]
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"token": "sprite-token"})
+
+    def fake_client(*args, **kwargs):
+        return real_client(transport=httpx.MockTransport(handler), **kwargs)
+
+    monkeypatch.setattr("sprites.client.httpx.Client", fake_client)
+
+    token = SpritesClient.create_token("fly-token", "acme", invite_code="invite-1")
+
+    assert token == "sprite-token"
+    assert captured == {
+        "url": "https://api.sprites.dev/v1/organizations/acme/tokens",
+        "auth": "FlyV1 fly-token",
+        "body": {
+            "description": "Sprite SDK Token",
+            "invite_code": "invite-1",
+        },
+    }
+
+
+def test_update_sprite_requires_a_mutable_field() -> None:
+    client = SpritesClient("test-token", base_url="https://api.test")
+
+    with pytest.raises(ValueError, match="url_settings or labels is required"):
+        client.update_sprite("demo")
+
+
+def test_update_url_settings_sends_private_access(make_mock_client) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PUT"
+        assert request.url.path == "/v1/sprites/demo"
+        assert json.loads(request.content) == {
+            "url_settings": {
+                "auth": "sprite",
+                "private_access": "admins",
+            }
+        }
+        return httpx.Response(204)
+
+    client = make_mock_client(handler)
+
+    client.update_url_settings("demo", URLSettings(auth="sprite", private_access="admins"))

--- a/tests/test_client_public_api.py
+++ b/tests/test_client_public_api.py
@@ -43,6 +43,8 @@ def test_get_sprite_parses_current_fields_and_encodes_name(make_mock_client) -> 
                 "labels": ["sdk", "python"],
                 "created_at": "2026-01-12T21:24:42Z",
                 "updated_at": "2026-01-12T21:25:42Z",
+                "last_running_at": "2026-01-12T21:26:42Z",
+                "last_warming_at": "2026-01-12T21:27:42Z",
             },
         )
 
@@ -57,6 +59,8 @@ def test_get_sprite_parses_current_fields_and_encodes_name(make_mock_client) -> 
     assert sprite.labels == ["sdk", "python"]
     assert sprite.created_at is not None
     assert sprite.updated_at is not None
+    assert sprite.last_running_at is not None
+    assert sprite.last_warming_at is not None
 
 
 def test_list_all_sprites_paginates_and_applies_prefix(make_mock_client) -> None:

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -2,6 +2,7 @@
 
 import pytest
 from sprites import SpritesClient
+from sprites._utils import quote_path_segment, websocket_base_url
 
 
 class TestControlModeClientOptions:
@@ -55,13 +56,10 @@ class TestControlURLBuilding:
 
         expected_url = "ws://localhost:8080/v1/sprites/my-sprite/control"
 
-        # Build actual URL (simulating what ControlConnection does)
-        base_url = sprite.client.base_url
-        if base_url.startswith("https"):
-            base_url = "wss" + base_url[5:]
-        elif base_url.startswith("http"):
-            base_url = "ws" + base_url[4:]
-        actual_url = f"{base_url}/v1/sprites/{sprite.name}/control"
+        actual_url = (
+            f"{websocket_base_url(sprite.client.base_url)}"
+            f"/v1/sprites/{quote_path_segment(sprite.name)}/control"
+        )
 
         assert actual_url == expected_url
 
@@ -70,14 +68,23 @@ class TestControlURLBuilding:
         client = SpritesClient(token="test-token", base_url="https://api.sprites.dev")
         sprite = client.sprite("my-sprite")
 
-        # Build actual URL
-        base_url = sprite.client.base_url
-        if base_url.startswith("https"):
-            base_url = "wss" + base_url[5:]
-        elif base_url.startswith("http"):
-            base_url = "ws" + base_url[4:]
-        actual_url = f"{base_url}/v1/sprites/{sprite.name}/control"
+        actual_url = (
+            f"{websocket_base_url(sprite.client.base_url)}"
+            f"/v1/sprites/{quote_path_segment(sprite.name)}/control"
+        )
 
         assert actual_url.startswith("wss://")
         assert "my-sprite" in actual_url
         assert "/control" in actual_url
+
+    def test_control_endpoint_url_encodes_sprite_name(self):
+        """Control endpoint URL should encode the sprite path segment."""
+        client = SpritesClient(token="test-token", base_url="https://api.sprites.dev")
+        sprite = client.sprite("my sprite/name")
+
+        actual_url = (
+            f"{websocket_base_url(sprite.client.base_url)}"
+            f"/v1/sprites/{quote_path_segment(sprite.name)}/control"
+        )
+
+        assert actual_url == "wss://api.sprites.dev/v1/sprites/my%20sprite%2Fname/control"

--- a/tests/test_filesystem_public_api.py
+++ b/tests/test_filesystem_public_api.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from sprites.exceptions import FileNotFoundError_
+
+
+def test_sprite_filesystem_builds_pathlike_objects(make_mock_client) -> None:
+    client = make_mock_client(lambda request: httpx.Response(500))
+    fs = client.sprite("demo").filesystem("/app")
+
+    path = fs.path("logs", "app.log")
+
+    assert repr(fs) == "SpriteFilesystem(sprite='demo', working_dir='/app')"
+    assert str(fs.cwd) == "/app"
+    assert str(fs.root) == "/"
+    assert str(path) == "/app/logs/app.log"
+    assert path.name == "app.log"
+    assert path.stem == "app"
+    assert path.suffix == ".log"
+    assert path.suffixes == [".log"]
+    assert str(path.parent) == "/app/logs"
+    assert path.parts == ("/", "app", "logs", "app.log")
+    assert path.is_absolute() is True
+    assert path.is_relative_to("/app") is True
+    assert str(path.with_name("other.txt")) == "/app/logs/other.txt"
+    assert str(path.with_stem("server")) == "/app/logs/server.log"
+    assert str(path.with_suffix(".txt")) == "/app/logs/app.txt"
+
+
+def test_filesystem_operations_use_current_api_shape(make_mock_client) -> None:
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        assert str(request.url).startswith("https://api.test/v1/sprites/demo%20fs/fs/")
+
+        if request.url.path.endswith("/list"):
+            params = dict(request.url.params)
+            assert params["workingDir"] == "/app"
+            if params["path"] == "/app/notes.txt":
+                return httpx.Response(
+                    200,
+                    json={
+                        "entries": [
+                            {
+                                "name": "notes.txt",
+                                "path": "/app/notes.txt",
+                                "size": 5,
+                                "mode": "0644",
+                                "modTime": "2026-01-12T21:24:42Z",
+                                "isDir": False,
+                            }
+                        ]
+                    },
+                )
+            if params["path"] == "/app/data":
+                return httpx.Response(
+                    200,
+                    json={
+                        "path": "/app/data",
+                        "entries": [
+                            {"name": "a.txt", "path": "/app/data/a.txt"},
+                            {"name": "b", "path": "/app/data/b"},
+                        ],
+                    },
+                )
+            return httpx.Response(404, json={"error": "missing"})
+
+        if request.url.path.endswith("/read"):
+            assert request.url.params["path"] == "/app/notes.txt"
+            return httpx.Response(200, content=b"hello")
+
+        if request.url.path.endswith("/write"):
+            assert request.method == "PUT"
+            assert dict(request.url.params) == {
+                "path": "/app/notes.txt",
+                "workingDir": "/app",
+                "mode": "0600",
+                "mkdirParents": "false",
+            }
+            assert request.content == b"updated"
+            return httpx.Response(200)
+
+        if request.url.path.endswith("/delete"):
+            assert request.method == "DELETE"
+            assert dict(request.url.params) == {
+                "path": "/app/notes.txt",
+                "workingDir": "/app",
+                "recursive": "false",
+            }
+            return httpx.Response(204)
+
+        body = json.loads(request.content)
+        if request.url.path.endswith("/rename"):
+            assert body == {
+                "source": "/app/notes.txt",
+                "dest": "/app/renamed.txt",
+                "workingDir": "/app",
+            }
+            return httpx.Response(200)
+
+        if request.url.path.endswith("/copy"):
+            assert body == {
+                "source": "/app/renamed.txt",
+                "dest": "/tmp/copy.txt",
+                "workingDir": "/app",
+                "recursive": False,
+            }
+            return httpx.Response(200)
+
+        if request.url.path.endswith("/chmod"):
+            assert body == {
+                "path": "/tmp/copy.txt",
+                "workingDir": "/app",
+                "mode": "0755",
+                "recursive": True,
+            }
+            return httpx.Response(200)
+
+        raise AssertionError(f"Unexpected filesystem path: {request.url.path}")
+
+    client = make_mock_client(handler)
+    fs = client.sprite("demo fs").filesystem("/app")
+    notes = fs / "notes.txt"
+
+    stat = notes.stat()
+    assert stat.name == "notes.txt"
+    assert stat.size == 5
+    assert stat.is_file is True
+    assert notes.read_text() == "hello"
+
+    notes.write_text("updated", mode=0o600, mkdir_parents=False)
+    assert (fs / "data").listdir() == ["a.txt", "b"]
+    notes.unlink()
+    renamed = notes.rename("renamed.txt")
+    copied = renamed.copy_to("/tmp/copy.txt", recursive=False)
+    copied.chmod(0o755, recursive=True)
+
+    assert str(renamed) == "/app/renamed.txt"
+    assert str(copied) == "/tmp/copy.txt"
+    assert [request.method for request in requests] == [
+        "GET",
+        "GET",
+        "PUT",
+        "GET",
+        "DELETE",
+        "POST",
+        "POST",
+        "POST",
+    ]
+
+
+def test_filesystem_exists_and_missing_ok_handle_not_found(make_mock_client) -> None:
+    delete_requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/list"):
+            return httpx.Response(404, json={"error": "missing"})
+        if request.url.path.endswith("/delete"):
+            delete_requests.append(request)
+            return httpx.Response(404, json={"error": "missing"})
+        raise AssertionError(f"Unexpected filesystem path: {request.url.path}")
+
+    client = make_mock_client(handler)
+    missing = client.sprite("demo").filesystem("/app") / "missing.txt"
+
+    assert missing.exists() is False
+    assert missing.is_file() is False
+    assert missing.is_dir() is False
+    missing.unlink(missing_ok=True)
+
+    with pytest.raises(FileNotFoundError_):
+        missing.unlink()
+
+    assert len(delete_requests) == 2

--- a/tests/test_sprite_public_api.py
+++ b/tests/test_sprite_public_api.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from sprites import NetworkPolicy, PolicyRule, SpritesClient, URLSettings
+from sprites.exceptions import ExitError, NotFoundError
+from sprites.exec import Cmd
+
+
+def test_destroy_and_delete_delegate_to_client_destroy(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = SpritesClient("test-token", base_url="https://api.test")
+    sprite = client.sprite("demo")
+    calls = []
+
+    def destroy_sprite(name: str) -> None:
+        calls.append(name)
+
+    monkeypatch.setattr(client, "destroy_sprite", destroy_sprite)
+
+    sprite.destroy()
+    sprite.delete()
+
+    assert calls == ["demo", "demo"]
+
+
+def test_update_helpers_delegate_to_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = SpritesClient("test-token", base_url="https://api.test")
+    sprite = client.sprite("demo")
+    settings = URLSettings(auth="public", private_access="admins")
+    calls = []
+
+    def update_url_settings(name: str, passed_settings: URLSettings) -> None:
+        calls.append(("url", name, passed_settings))
+
+    def update_sprite(name: str, **kwargs):
+        calls.append(("sprite", name, kwargs))
+        return "updated"
+
+    monkeypatch.setattr(client, "update_url_settings", update_url_settings)
+    monkeypatch.setattr(client, "update_sprite", update_sprite)
+
+    sprite.update_url_settings(settings)
+    result = sprite.update(url_settings=settings, labels=["sdk"])
+
+    assert result == "updated"
+    assert calls == [
+        ("url", "demo", settings),
+        (
+            "sprite",
+            "demo",
+            {"url_settings": settings, "labels": ["sdk"]},
+        ),
+    ]
+
+
+def test_upgrade_delegates_to_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = SpritesClient("test-token", base_url="https://api.test")
+    sprite = client.sprite("demo")
+    calls = []
+
+    monkeypatch.setattr(client, "upgrade_sprite", lambda name: calls.append(name))
+
+    sprite.upgrade()
+
+    assert calls == ["demo"]
+
+
+def test_list_sessions_parses_session_metadata(make_mock_client) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/v1/sprites/demo/exec"
+        return httpx.Response(
+            200,
+            json={
+                "sessions": [
+                    {
+                        "id": "sess-1",
+                        "command": "bash",
+                        "workdir": "/app",
+                        "created": "2026-01-12T21:24:42Z",
+                        "bytes_per_second": 42,
+                        "is_active": True,
+                        "tty": True,
+                        "last_activity": "2026-01-12T21:25:42Z",
+                    }
+                ]
+            },
+        )
+
+    client = make_mock_client(handler)
+
+    sessions = client.sprite("demo").list_sessions()
+
+    assert len(sessions) == 1
+    assert sessions[0].id == "sess-1"
+    assert sessions[0].tty is True
+    assert sessions[0].last_activity is not None
+
+
+def test_list_and_get_checkpoints_parse_and_encode_paths(make_mock_client) -> None:
+    seen_paths = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        encoded_path = str(request.url).split("?", 1)[0].removeprefix("https://api.test")
+        seen_paths.append(encoded_path)
+        if request.url.path == "/v1/sprites/demo/checkpoints":
+            assert request.url.params["history"] == "ancestors"
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "checkpoint one",
+                        "create_time": "2026-01-12T21:24:42Z",
+                        "comment": "before change",
+                        "history": "ancestors",
+                    }
+                ],
+            )
+
+        assert encoded_path == "/v1/sprites/demo/checkpoints/checkpoint%20one"
+        return httpx.Response(
+            200,
+            json={
+                "id": "checkpoint one",
+                "create_time": "2026-01-12T21:24:42Z",
+                "comment": "before change",
+                "history": "ancestors",
+            },
+        )
+
+    client = make_mock_client(handler)
+    sprite = client.sprite("demo")
+
+    checkpoints = sprite.list_checkpoints(history_filter="ancestors")
+    checkpoint = sprite.get_checkpoint("checkpoint one")
+
+    assert checkpoints[0].id == "checkpoint one"
+    assert checkpoint.comment == "before change"
+    assert seen_paths == [
+        "/v1/sprites/demo/checkpoints",
+        "/v1/sprites/demo/checkpoints/checkpoint%20one",
+    ]
+
+
+def test_get_checkpoint_raises_not_found(make_mock_client) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, text="missing")
+
+    client = make_mock_client(handler)
+
+    with pytest.raises(NotFoundError):
+        client.sprite("demo").get_checkpoint("missing")
+
+
+def test_network_policy_round_trip(make_mock_client) -> None:
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append((request.method, request.url.path))
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "rules": [
+                        {"domain": "example.com", "action": "allow"},
+                        {"include": "defaults"},
+                    ]
+                },
+            )
+
+        assert request.method == "POST"
+        assert json.loads(request.content) == {
+            "rules": [
+                {"domain": "example.org", "action": "deny"},
+                {"include": "defaults"},
+            ]
+        }
+        return httpx.Response(204)
+
+    client = make_mock_client(handler)
+    sprite = client.sprite("demo")
+
+    policy = sprite.get_network_policy()
+    sprite.update_network_policy(
+        NetworkPolicy(
+            rules=[
+                PolicyRule(domain="example.org", action="deny"),
+                PolicyRule(include="defaults"),
+            ]
+        )
+    )
+
+    assert policy.rules[0].domain == "example.com"
+    assert policy.rules[1].include == "defaults"
+    assert calls == [
+        ("GET", "/v1/sprites/demo/policy/network"),
+        ("POST", "/v1/sprites/demo/policy/network"),
+    ]
+
+
+def test_get_delete_and_signal_service_requests(make_mock_client) -> None:
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        encoded_path = str(request.url).removeprefix("https://api.test")
+        calls.append((request.method, encoded_path, request.content))
+        if request.method == "GET":
+            assert encoded_path == "/v1/sprites/demo/services/web%2Fapi"
+            return httpx.Response(
+                200,
+                json={
+                    "name": "web/api",
+                    "cmd": "python",
+                    "args": ["-m", "http.server"],
+                    "needs": [],
+                    "http_port": 8000,
+                    "state": {"name": "web/api", "status": "running"},
+                },
+            )
+        if request.method == "DELETE":
+            assert encoded_path == "/v1/sprites/demo/services/web%2Fapi"
+            return httpx.Response(204)
+
+        assert request.method == "POST"
+        assert request.url.path == "/v1/sprites/demo/services/signal"
+        assert json.loads(request.content) == {"name": "web/api", "signal": "SIGTERM"}
+        return httpx.Response(204)
+
+    client = make_mock_client(handler)
+    sprite = client.sprite("demo")
+
+    service = sprite.get_service("web/api")
+    sprite.delete_service("web/api")
+    sprite.signal_service("web/api", "SIGTERM")
+
+    assert service.name == "web/api"
+    assert [method for method, _, _ in calls] == ["GET", "DELETE", "POST"]
+
+
+def test_run_returns_completed_process_with_captured_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def run_sync(cmd: Cmd) -> int:
+        cmd._stdout_data = b"out"
+        cmd._stderr_data = b"err"
+        return 0
+
+    monkeypatch.setattr(Cmd, "_run_sync", run_sync)
+    sprite = SpritesClient("test-token", base_url="https://api.test").sprite("demo")
+
+    result = sprite.run("echo", "hi", capture_output=True, tty=True, tty_rows=40)
+
+    assert result.args == ["echo", "hi"]
+    assert result.returncode == 0
+    assert result.stdout == b"out"
+    assert result.stderr == b"err"
+
+
+def test_run_check_raises_exit_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Cmd, "_run_sync", lambda cmd: 2)
+    sprite = SpritesClient("test-token", base_url="https://api.test").sprite("demo")
+
+    with pytest.raises(ExitError) as exc_info:
+        sprite.run("false", check=True)
+
+    assert exc_info.value.exit_code() == 2

--- a/tests/test_stream_public_api.py
+++ b/tests/test_stream_public_api.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+
+import sprites.checkpoint as checkpoint_module
+import sprites.services as services_module
+from sprites import SpritesClient
+from sprites.checkpoint import CheckpointStream, RestoreStream
+from sprites.services import ServiceStream
+
+
+def test_checkpoint_and_restore_streams_skip_invalid_lines() -> None:
+    checkpoint_response = httpx.Response(
+        200,
+        text='not json\n{"type":"progress","data":{"step":1}}\n\n{"type":"done"}\n',
+    )
+    restore_response = httpx.Response(
+        200,
+        text='{"type":"restoring"}\ninvalid\n{"type":"done","error":null}\n',
+    )
+
+    checkpoint_messages = list(CheckpointStream(checkpoint_response))
+    restore_messages = list(RestoreStream(restore_response))
+
+    assert [message.type for message in checkpoint_messages] == ["progress", "done"]
+    assert checkpoint_messages[0].data == {"step": 1}
+    assert [message.type for message in restore_messages] == ["restoring", "done"]
+
+
+def test_create_and_restore_checkpoint_post_and_parse_streams(
+    monkeypatch,
+) -> None:
+    captured = []
+    responses = [
+        httpx.Response(200, text='{"type":"progress","data":"saving"}\n{"type":"done"}\n'),
+        httpx.Response(200, text='{"type":"progress","data":"restoring"}\n{"type":"done"}\n'),
+    ]
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def post(self, url, **kwargs):
+            captured.append((url, kwargs))
+            return responses.pop(0)
+
+    monkeypatch.setattr(checkpoint_module.httpx, "Client", FakeClient)
+    sprite = SpritesClient("test-token", base_url="https://api.test").sprite("demo/name")
+
+    create_messages = list(sprite.create_checkpoint("before upgrade"))
+    restore_messages = list(sprite.restore_checkpoint("checkpoint one"))
+
+    assert [message.type for message in create_messages] == ["progress", "done"]
+    assert [message.type for message in restore_messages] == ["progress", "done"]
+    assert captured[0] == (
+        "https://api.test/v1/sprites/demo%2Fname/checkpoint",
+        {
+            "json": {"comment": "before upgrade"},
+            "headers": {"Content-Type": "application/json"},
+        },
+    )
+    assert captured[1] == (
+        "https://api.test/v1/sprites/demo%2Fname/checkpoints/checkpoint%20one/restore",
+        {},
+    )
+
+
+def test_service_stream_process_all() -> None:
+    stream = ServiceStream(
+        [
+            services_module.ServiceLogEvent(type="log", data="first"),
+            services_module.ServiceLogEvent(type="exit", exit_code=0),
+        ]
+    )
+    handled = []
+
+    stream.process_all(handled.append)
+
+    assert [event.type for event in handled] == ["log", "exit"]
+
+
+def test_create_start_and_stop_service_post_and_parse_streams(monkeypatch) -> None:
+    captured = []
+    responses = [
+        httpx.Response(200, text='{"type":"log","data":"created"}\n{"type":"exit","exit_code":0}\n'),
+        httpx.Response(200, text='{"type":"log","data":"started"}\n'),
+        httpx.Response(200, text='{"type":"log","data":"stopped"}\n'),
+    ]
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def put(self, url, **kwargs):
+            captured.append(("PUT", url, kwargs))
+            return responses.pop(0)
+
+        def post(self, url, **kwargs):
+            captured.append(("POST", url, kwargs))
+            return responses.pop(0)
+
+    monkeypatch.setattr(services_module.httpx, "Client", FakeClient)
+    sprite = SpritesClient("test-token", base_url="https://api.test").sprite("demo/name")
+
+    create_events = list(
+        sprite.create_service(
+            "web api",
+            "python",
+            args=["-m", "http.server"],
+            needs=["db"],
+            http_port=8000,
+            duration=1.5,
+        )
+    )
+    start_events = list(sprite.start_service("web api", duration=2.0))
+    stop_events = list(sprite.stop_service("web api", timeout=3.0))
+
+    assert [event.type for event in create_events] == ["log", "exit"]
+    assert create_events[1].exit_code == 0
+    assert start_events[0].data == "started"
+    assert stop_events[0].data == "stopped"
+    assert captured[0] == (
+        "PUT",
+        "https://api.test/v1/sprites/demo%2Fname/services/web%20api?duration=1.5s",
+        {
+            "json": {
+                "cmd": "python",
+                "args": ["-m", "http.server"],
+                "needs": ["db"],
+                "http_port": 8000,
+            }
+        },
+    )
+    assert captured[1] == (
+        "POST",
+        "https://api.test/v1/sprites/demo%2Fname/services/web%20api/start?duration=2.0s",
+        {},
+    )
+    assert captured[2] == (
+        "POST",
+        "https://api.test/v1/sprites/demo%2Fname/services/web%20api/stop?timeout=3.0s",
+        {},
+    )


### PR DESCRIPTION
## Summary
- update SDK request/response handling for the current sprites-api contract
- prefer destroy terminology while keeping delete aliases for compatibility
- refresh README and examples to match the SDK surface
- add mocked coverage for public client, sprite, filesystem, service, checkpoint, and stream methods
- centralize sprite API URL construction and response parsing to avoid drift
- bump package version to 0.2.0 and add a changelog entry for public API shape changes

## Review follow-up
- Verified in the local sprites-api source that PUT /v1/sprites/:name is a partial update: the controller checks present keys and independently updates url_settings and labels, so omitted mutable fields are left unchanged.
- Documented the partial update behavior and kept update_url_settings as a compatibility convenience while steering users to update_sprite/update.
- Unified SpriteInfo/Sprite hydration so runtime timestamps and URL settings parse consistently.
- Replaced repeated sprite base URL builders with shared helpers and fixed control-mode URL path encoding.
- Added a Sprite.run note explaining that command() is the streaming API.

## User impact
Users get docs and examples that match the current Python SDK behavior, plus SDK methods that line up with current sprites-api field names and endpoint shapes. The 0.2.0 changelog calls out public service API shape/type changes for consumers upgrading from 0.1.x.

## Deployment
No service deployment required. This is a Python SDK/package change.

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q
- PYTHONPYCACHEPREFIX=/private/tmp/sprites-py-pycache python3 -m compileall -q src tests examples test_cli
- git diff --check