### PR TITLE
Attach client-signals to outbound API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,11 +178,23 @@ new_policy = NetworkPolicy(rules=[
 sprite.update_network_policy(new_policy)
 ```
 
+## Client signals
+
+Requests carry coarse, privacy-safe [client signals](https://github.com/superfly/client-signals)
+(`Fly-Client-*` headers + a User-Agent suffix) so Fly.io can estimate how much
+API traffic is human- vs. agent-driven. They're advisory only — never used for
+gating or rate-limiting.
+
+To opt out, set `SPRITES_CLIENT_SIGNALS=0` (also accepts `off`/`false`/`no`).
+When disabled, requests still send a plain `sprites-py/<version>` User-Agent and
+no `Fly-Client-*` headers — the SDK is otherwise unaffected.
+
 ## Requirements
 
 - Python 3.9+
 - websockets
 - httpx
+- client-signals
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,8 @@ classifiers = [
 dependencies = [
     "httpx>=0.25.0",
     "websockets>=12.0",
-    # Human-vs-agent client signals. Git ref until the Python package is
-    # published to PyPI; pin to a tag/commit once available.
-    "client-signals @ git+https://github.com/superfly/client-signals.git@main#subdirectory=python",
+    # Human-vs-agent client signals (Fly-Client-* headers + User-Agent suffix).
+    "client-signals>=0.4.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ classifiers = [
 dependencies = [
     "httpx>=0.25.0",
     "websockets>=12.0",
+    # Human-vs-agent client signals. Git ref until the Python package is
+    # published to PyPI; pin to a tag/commit once available.
+    "client-signals @ git+https://github.com/superfly/client-signals.git@main#subdirectory=python",
 ]
 
 [project.optional-dependencies]

--- a/src/sprites/_signals.py
+++ b/src/sprites/_signals.py
@@ -1,0 +1,50 @@
+"""Client-signals integration.
+
+Attaches coarse, privacy-safe human-vs-AI-agent signals to outbound Sprites API
+requests using github.com/superfly/client-signals: a set of ``Fly-Client-*``
+headers plus a User-Agent suffix, so backend traffic can be attributed to
+humans vs. agents.
+
+Detection is computed once per process (never per request). Attribution is
+best-effort and never changes request behavior: if the ``client_signals``
+package is unavailable, requests still go out, carrying only a plain
+``sprites-py`` User-Agent.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Dict
+
+try:
+    import client_signals
+except ImportError:  # degrade gracefully; the dependency is declared but optional at runtime
+    client_signals = None  # type: ignore[assignment]
+
+
+def _base_user_agent() -> str:
+    # Deferred import: avoids a circular import at module load time, since the
+    # package __init__ imports the client which imports this module.
+    from . import __version__
+
+    return f"sprites-py/{__version__}"
+
+
+@functools.lru_cache(maxsize=1)
+def _computed() -> Dict[str, str]:
+    ua = _base_user_agent()
+    if client_signals is None:
+        return {"User-Agent": ua}
+    signals = client_signals.detect_once()
+    headers = client_signals.headers_for(signals)
+    headers["User-Agent"] = f"{ua} {client_signals.user_agent_suffix(signals)}"
+    return headers
+
+
+def signal_headers() -> Dict[str, str]:
+    """Return the client-signal headers (including User-Agent), computed once.
+
+    Returns a fresh copy each call, so callers may safely merge in their own
+    headers (e.g. Authorization) without mutating the cached result.
+    """
+    return dict(_computed())

--- a/src/sprites/_signals.py
+++ b/src/sprites/_signals.py
@@ -6,14 +6,18 @@ headers plus a User-Agent suffix, so backend traffic can be attributed to
 humans vs. agents.
 
 Detection is computed once per process (never per request). Attribution is
-best-effort and never changes request behavior: if the ``client_signals``
-package is unavailable, requests still go out, carrying only a plain
-``sprites-py`` User-Agent.
+best-effort and never changes request behavior.
+
+Opting out: set ``SPRITES_CLIENT_SIGNALS`` to ``0`` / ``off`` / ``false`` /
+``no``. When disabled (or if the ``client_signals`` package is unavailable),
+requests still go out carrying only a plain ``sprites-py`` User-Agent (client
+identification, not attribution) and no ``Fly-Client-*`` headers.
 """
 
 from __future__ import annotations
 
 import functools
+import os
 from typing import Dict
 
 try:
@@ -30,10 +34,19 @@ def _base_user_agent() -> str:
     return f"sprites-py/{__version__}"
 
 
+_DISABLE_VALUES = {"0", "off", "false", "no", "disabled"}
+
+
+def _disabled() -> bool:
+    return os.environ.get("SPRITES_CLIENT_SIGNALS", "").strip().lower() in _DISABLE_VALUES
+
+
 @functools.lru_cache(maxsize=1)
 def _computed() -> Dict[str, str]:
     ua = _base_user_agent()
-    if client_signals is None:
+    # When opted out (or without the dependency) we never touch client_signals:
+    # no detection runs and only the plain client-identification UA is sent.
+    if client_signals is None or _disabled():
         return {"User-Agent": ua}
     signals = client_signals.detect_once()
     headers = client_signals.headers_for(signals)

--- a/src/sprites/checkpoint.py
+++ b/src/sprites/checkpoint.py
@@ -11,6 +11,7 @@ import httpx
 from sprites.exceptions import APIError
 from sprites.types import Checkpoint, StreamMessage
 from sprites._utils import quote_path_segment, sprite_base_url
+from sprites._signals import signal_headers
 
 if TYPE_CHECKING:
     from sprites.sprite import Sprite
@@ -224,7 +225,7 @@ def create_checkpoint(sprite: Sprite, comment: str = "") -> CheckpointStream:
     # Use a separate client for streaming with no timeout
     with httpx.Client(
         timeout=None,
-        headers={"Authorization": f"Bearer {sprite.client.token}"},
+        headers={**signal_headers(), "Authorization": f"Bearer {sprite.client.token}"},
     ) as client:
         try:
             response = client.post(url, json=payload, headers={"Content-Type": "application/json"})
@@ -279,7 +280,7 @@ def restore_checkpoint(sprite: Sprite, checkpoint_id: str) -> RestoreStream:
     # Use a separate client for streaming with no timeout
     with httpx.Client(
         timeout=None,
-        headers={"Authorization": f"Bearer {sprite.client.token}"},
+        headers={**signal_headers(), "Authorization": f"Bearer {sprite.client.token}"},
     ) as client:
         try:
             response = client.post(url)

--- a/src/sprites/client.py
+++ b/src/sprites/client.py
@@ -26,6 +26,7 @@ from ._utils import (
     parse_url_settings,
     sprite_base_url,
 )
+from ._signals import signal_headers
 
 
 class SpritesClient:
@@ -51,7 +52,11 @@ class SpritesClient:
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self.control_mode = control_mode
-        self._client = httpx.Client(timeout=timeout)
+        # Attach client-signals headers/User-Agent to every request from this
+        # client. Per-request headers (Authorization, Content-Type) are merged
+        # on top by httpx. The separate token-minting client in create_token
+        # deliberately does not carry these.
+        self._client = httpx.Client(timeout=timeout, headers=signal_headers())
 
     def __enter__(self) -> "SpritesClient":
         return self

--- a/src/sprites/control.py
+++ b/src/sprites/control.py
@@ -11,6 +11,7 @@ import websockets
 from websockets.exceptions import ConnectionClosed
 
 from sprites._utils import quote_path_segment, websocket_base_url
+from sprites._signals import signal_headers
 
 if TYPE_CHECKING:
     from .sprite import Sprite
@@ -222,7 +223,10 @@ class ControlConnection:
         base_url = websocket_base_url(self.sprite.client.base_url)
         sprite_name = quote_path_segment(self.sprite.name)
         url = f"{base_url}/v1/sprites/{sprite_name}/control"
-        headers = {"Authorization": f"Bearer {self.sprite.client.token}"}
+        headers = {
+            "Authorization": f"Bearer {self.sprite.client.token}",
+            **signal_headers(),
+        }
 
         self.ws = await websockets.connect(
             url,

--- a/src/sprites/services.py
+++ b/src/sprites/services.py
@@ -11,6 +11,7 @@ import httpx
 from sprites.exceptions import APIError
 from sprites.types import ServiceLogEvent, ServiceState, ServiceWithState
 from sprites._utils import quote_path_segment, sprite_base_url
+from sprites._signals import signal_headers
 
 if TYPE_CHECKING:
     from sprites.sprite import Sprite
@@ -235,7 +236,7 @@ def create_service(
 
     with httpx.Client(
         timeout=120.0,
-        headers={"Authorization": f"Bearer {sprite.client.token}"},
+        headers={**signal_headers(), "Authorization": f"Bearer {sprite.client.token}"},
     ) as client:
         try:
             response = client.put(url, json=payload)
@@ -318,7 +319,7 @@ def start_service(
 
     with httpx.Client(
         timeout=120.0,
-        headers={"Authorization": f"Bearer {sprite.client.token}"},
+        headers={**signal_headers(), "Authorization": f"Bearer {sprite.client.token}"},
     ) as client:
         try:
             response = client.post(url)
@@ -362,7 +363,7 @@ def stop_service(
 
     with httpx.Client(
         timeout=120.0,
-        headers={"Authorization": f"Bearer {sprite.client.token}"},
+        headers={**signal_headers(), "Authorization": f"Bearer {sprite.client.token}"},
     ) as client:
         try:
             response = client.post(url)

--- a/src/sprites/session.py
+++ b/src/sprites/session.py
@@ -11,6 +11,7 @@ import httpx
 from sprites.exceptions import APIError
 from sprites.types import Session, StreamMessage
 from sprites._utils import quote_path_segment, sprite_base_url
+from sprites._signals import signal_headers
 
 if TYPE_CHECKING:
     from sprites.sprite import Sprite
@@ -157,7 +158,7 @@ def kill_session(
     # Use a separate client for streaming with extended timeout
     with httpx.Client(
         timeout=120.0,
-        headers={"Authorization": f"Bearer {sprite.client.token}"},
+        headers={**signal_headers(), "Authorization": f"Bearer {sprite.client.token}"},
     ) as client:
         try:
             response = client.post(url, json=payload)

--- a/src/sprites/websocket.py
+++ b/src/sprites/websocket.py
@@ -13,6 +13,7 @@ from websockets.exceptions import ConnectionClosed, InvalidStatusCode, InvalidSt
 
 from sprites.exceptions import parse_api_error
 from sprites._utils import quote_path_segment, websocket_base_url
+from sprites._signals import signal_headers
 
 if TYPE_CHECKING:
     from sprites.exec import Cmd
@@ -103,7 +104,10 @@ class WSCommand:
         self.started = True
 
         url = self._build_websocket_url()
-        headers = {"Authorization": f"Bearer {self.cmd.sprite.client.token}"}
+        headers = {
+            "Authorization": f"Bearer {self.cmd.sprite.client.token}",
+            **signal_headers(),
+        }
 
         try:
             self.ws = await websockets.connect(

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,12 +1,18 @@
 """Tests for client-signals integration (Fly-Client-* headers + User-Agent)."""
 
+import types
+
 import httpx
 import pytest
 
+import sprites.checkpoint as checkpoint_mod
 import sprites.client as client_module
+import sprites.services as services_mod
+import sprites.session as session_mod
 import sprites._signals as signals_module
 from sprites import SpritesClient
 from sprites._signals import signal_headers
+from sprites.exceptions import APIError
 
 _PARENT_BUCKETS = {"node", "python", "shell", "other"}
 
@@ -153,3 +159,74 @@ def test_works_without_client_signals_installed(monkeypatch):
     client = SpritesClient(token="test-token")  # still fully functional
     assert not _has_fly_headers(client._client.headers.keys())
     client.close()
+
+
+# -- transient (non-shared) REST clients must also carry signals --------------
+#
+# Checkpoint, service, and session-kill paths each build their own httpx.Client
+# instead of using SpritesClient._client, so they need signals merged in too.
+
+
+class _CapturingClient:
+    """Records the headers a transient client is constructed with, then fails
+    the request (so we don't need a real server or response parsing)."""
+
+    captured_headers = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).captured_headers = kwargs.get("headers") or {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def _fail(self, *args, **kwargs):
+        raise httpx.RequestError("no network in tests")
+
+    get = post = put = delete = _fail
+
+
+def _fake_sprite():
+    client = types.SimpleNamespace(token="tok", base_url="https://api.sprites.dev")
+    return types.SimpleNamespace(name="s", client=client)
+
+
+_BYPASS_CALLS = [
+    ("create_checkpoint", lambda s: checkpoint_mod.create_checkpoint(s, "c")),
+    ("restore_checkpoint", lambda s: checkpoint_mod.restore_checkpoint(s, "v1")),
+    ("create_service", lambda s: services_mod.create_service(s, "web", "run")),
+    ("start_service", lambda s: services_mod.start_service(s, "web")),
+    ("stop_service", lambda s: services_mod.stop_service(s, "web")),
+    ("kill_session", lambda s: session_mod.kill_session(s, "sess-1")),
+]
+
+
+@pytest.mark.parametrize("name, call", _BYPASS_CALLS, ids=[c[0] for c in _BYPASS_CALLS])
+def test_transient_clients_carry_signal_headers(monkeypatch, name, call):
+    _CapturingClient.captured_headers = None
+    monkeypatch.setattr(httpx, "Client", _CapturingClient)
+
+    with pytest.raises(APIError):  # the capturing client fails the request
+        call(_fake_sprite())
+
+    headers = _CapturingClient.captured_headers
+    assert _has_fly_headers(headers), f"{name} sent no Fly-Client-* headers"
+    assert any("bearer" in str(v).lower() for v in headers.values()), (
+        f"{name} dropped Authorization"
+    )
+
+
+def test_transient_client_respects_opt_out(monkeypatch):
+    # The opt-out must reach the transient paths too, not just the shared client.
+    monkeypatch.setenv("SPRITES_CLIENT_SIGNALS", "0")
+    _CapturingClient.captured_headers = None
+    monkeypatch.setattr(httpx, "Client", _CapturingClient)
+
+    with pytest.raises(APIError):
+        checkpoint_mod.create_checkpoint(_fake_sprite(), "c")
+
+    headers = _CapturingClient.captured_headers
+    assert not _has_fly_headers(headers)
+    assert any("bearer" in str(v).lower() for v in headers.values())  # auth still sent

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,12 +1,27 @@
 """Tests for client-signals integration (Fly-Client-* headers + User-Agent)."""
 
 import httpx
+import pytest
 
 import sprites.client as client_module
+import sprites._signals as signals_module
 from sprites import SpritesClient
 from sprites._signals import signal_headers
 
 _PARENT_BUCKETS = {"node", "python", "shell", "other"}
+
+
+@pytest.fixture(autouse=True)
+def _fresh_signal_cache():
+    # signal_headers() caches its result for the process; clear it around each
+    # test so env/dependency changes take effect and tests stay order-independent.
+    signals_module._computed.cache_clear()
+    yield
+    signals_module._computed.cache_clear()
+
+
+def _has_fly_headers(headers):
+    return any(str(k).lower().startswith("fly-client-") for k in headers)
 
 
 def test_signal_headers_shape():
@@ -82,3 +97,59 @@ def test_token_minting_path_excludes_signals(monkeypatch):
     sent = _RecordingClient.post_headers or {}
     assert not any(k.lower().startswith("fly-client-") for k in sent)
     assert "sprites-py/" not in sent.get("User-Agent", "")
+
+
+# -- opting out: the SDK must work fully without attribution -------------------
+
+
+def test_disabled_sends_only_plain_user_agent(monkeypatch):
+    monkeypatch.setenv("SPRITES_CLIENT_SIGNALS", "0")
+    headers = signal_headers()
+    # Only a plain client-identification UA; no attribution.
+    assert list(headers) == ["User-Agent"]
+    assert headers["User-Agent"].startswith("sprites-py/")
+    assert "interactive=" not in headers["User-Agent"]  # no signal suffix
+    assert not _has_fly_headers(headers)
+
+
+@pytest.mark.parametrize("value", ["0", "off", "false", "no", "disabled", "OFF", " No "])
+def test_disable_accepts_common_falsey_values(monkeypatch, value):
+    monkeypatch.setenv("SPRITES_CLIENT_SIGNALS", value)
+    assert list(signal_headers()) == ["User-Agent"]
+
+
+def test_enabled_by_default(monkeypatch):
+    monkeypatch.delenv("SPRITES_CLIENT_SIGNALS", raising=False)
+    assert _has_fly_headers(signal_headers())
+
+
+def test_disabled_client_still_works_without_fly_headers(monkeypatch):
+    monkeypatch.setenv("SPRITES_CLIENT_SIGNALS", "off")
+    client = SpritesClient(token="test-token")  # SDK constructs normally
+    headers = client._client.headers
+    assert headers["user-agent"].startswith("sprites-py/")
+    assert not _has_fly_headers(headers.keys())
+    client.close()
+
+
+def test_disabled_never_runs_detection(monkeypatch):
+    # Opting out must bypass client_signals entirely, not just drop its output.
+    monkeypatch.setenv("SPRITES_CLIENT_SIGNALS", "off")
+    if signals_module.client_signals is not None:
+        def _boom(*args, **kwargs):
+            raise AssertionError("detection must not run when disabled")
+
+        monkeypatch.setattr(signals_module.client_signals, "detect_once", _boom)
+    assert list(signal_headers()) == ["User-Agent"]  # does not raise
+
+
+def test_works_without_client_signals_installed(monkeypatch):
+    # Simulate the dependency being absent: the SDK degrades to a plain UA.
+    monkeypatch.setattr(signals_module, "client_signals", None)
+    headers = signal_headers()
+    assert list(headers) == ["User-Agent"]
+    assert headers["User-Agent"].startswith("sprites-py/")
+
+    client = SpritesClient(token="test-token")  # still fully functional
+    assert not _has_fly_headers(client._client.headers.keys())
+    client.close()

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,84 @@
+"""Tests for client-signals integration (Fly-Client-* headers + User-Agent)."""
+
+import httpx
+
+import sprites.client as client_module
+from sprites import SpritesClient
+from sprites._signals import signal_headers
+
+_PARENT_BUCKETS = {"node", "python", "shell", "other"}
+
+
+def test_signal_headers_shape():
+    headers = signal_headers()
+    # Always identifies sprites-py, regardless of environment.
+    assert headers["User-Agent"].startswith("sprites-py/")
+    # Coarse, finite-valued signals.
+    assert headers["Fly-Client-Parent"] in _PARENT_BUCKETS
+    assert headers["Fly-Client-Interactive"] in {"true", "false"}
+
+
+def test_signal_headers_returns_fresh_copy():
+    a = signal_headers()
+    a["Authorization"] = "Bearer x"  # callers merge auth on top
+    b = signal_headers()
+    assert "Authorization" not in b
+
+
+def test_rest_client_carries_signal_headers():
+    client = SpritesClient(token="test-token")
+    headers = client._client.headers  # httpx default headers, sent on every request
+    assert headers["user-agent"].startswith("sprites-py/")
+    assert headers["fly-client-parent"] in _PARENT_BUCKETS
+    assert headers["fly-client-interactive"] in {"true", "false"}
+
+
+def test_user_agent_contains_signal_suffix():
+    # The client-signals suffix is appended to the base UA, e.g.
+    # "sprites-py/0.2.0 (interactive=false; parent=python)".
+    ua = signal_headers()["User-Agent"]
+    assert "interactive=" in ua and ua.rstrip().endswith(")")
+
+
+class _RecordingResponse:
+    status_code = 200
+    is_success = True
+    text = ""
+
+    def json(self):
+        return {"token": "minted-token"}
+
+
+class _RecordingClient:
+    """Captures how create_token constructs its transient httpx client."""
+
+    init_kwargs = None
+    post_headers = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).init_kwargs = kwargs
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def post(self, url, headers=None, json=None):
+        type(self).post_headers = headers
+        return _RecordingResponse()
+
+
+def test_token_minting_path_excludes_signals(monkeypatch):
+    # The auth/token path must never carry client-signals headers.
+    monkeypatch.setattr(client_module.httpx, "Client", _RecordingClient)
+
+    token = SpritesClient.create_token("fly-macaroon", "my-org")
+    assert token == "minted-token"
+
+    # Its transient client is built without signal default headers ...
+    assert "headers" not in (_RecordingClient.init_kwargs or {})
+    # ... and the request itself carries only auth/content-type, no Fly-Client-*.
+    sent = _RecordingClient.post_headers or {}
+    assert not any(k.lower().startswith("fly-client-") for k in sent)
+    assert "sprites-py/" not in sent.get("User-Agent", "")


### PR DESCRIPTION
## Summary

Integrates [`superfly/client-signals`](https://github.com/superfly/client-signals) so Sprites API traffic can be attributed to humans vs. AI agents — the Python counterpart to what `fly-go` already emits, using the **same contract** (`Fly-Client-*` headers + a User-Agent suffix).

## What changed

- **`_signals.py`** — computes signals once per process (`client_signals.detect_once()`) and builds the `Fly-Client-*` headers plus a `sprites-py/<version> (interactive=…; parent=…; agent=…)` User-Agent.
- **REST** — the shared `httpx.Client` is built with these as default headers; per-request `Authorization`/`Content-Type` merge on top.
- **WebSocket** — both exec (`websocket.py`) and control (`control.py`) merge the same headers into the handshake `additional_headers`.
- **Auth path excluded** — `create_token` uses a separate transient client and never carries these headers (guarded by a test).
- **Opt-out** — set `SPRITES_CLIENT_SIGNALS=0` (or `off`/`false`/`no`). When disabled, detection never runs and requests carry only a plain `sprites-py` User-Agent with no `Fly-Client-*` headers. Documented in the README.
- **Dependency** — `client-signals>=0.4.1` from PyPI.

Side benefit: sprites-py previously sent **no** User-Agent (bare `python-httpx/*`); it now identifies itself.

## Verification

- `tests/test_signals.py` (17 tests) + full suite: **78 passed**, with `client-signals` resolved from PyPI (0.4.1). Tests cover: headers present on REST/UA suffix; auth path excluded; the opt-out path (SDK works, no signal headers); that disabling **bypasses** detection rather than dropping its output; and that the SDK works fully when `client_signals` is not installed.
- End-to-end with the Sprites ADK plugin declaring `FLY_INVOKED_BY=google-adk`: `User-Agent: sprites-py/0.2.0 (… agent=google-adk)`, `Fly-Client-Agent: google-adk`. With `SPRITES_CLIENT_SIGNALS=0`: `{"User-Agent": "sprites-py/0.2.0"}`.

## Notes

- On by default (coarse, privacy-safe, advisory-only); opt out via `SPRITES_CLIENT_SIGNALS`.
- Version bump left to your release cadence.