### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sprites-py"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python SDK for the Sprites API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/sprites/__init__.py
+++ b/src/sprites/__init__.py
@@ -63,7 +63,7 @@ from .types import (
     DirEntry,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     # Main classes


### PR DESCRIPTION
Minor version bump so the **client-signals attribution** feature ([#29](https://github.com/superfly/sprites-py/pull/29)) ships to PyPI.

- `0.2.0` → `0.3.0` in `pyproject.toml` and `src/sprites/__init__.py`.
- Minor (not patch): adds a feature (`Fly-Client-*` headers + User-Agent, opt-out via `SPRITES_CLIENT_SIGNALS`) and a new dependency (`client-signals>=0.4.1`).

After merge, tagging `v0.3.0` publishes to PyPI via the existing trusted-publishing workflow. Pre-flighted locally: builds clean, `twine check` passes, and the package declares `Requires-Dist: client-signals>=0.4.1`.

Unblocks pinning sprites-adk's floor to a client-signals-capable sprites-py.