### PR TITLE
Harden OpenAI Agents package publishing

### DIFF
--- a/.github/workflows/openai-agents.yml
+++ b/.github/workflows/openai-agents.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "integrations/openai-agents/**"
       - ".github/workflows/openai-agents.yml"
+      - ".github/workflows/publish-openai-agents.yml"
   push:
     branches:
       - main
     paths:
       - "integrations/openai-agents/**"
       - ".github/workflows/openai-agents.yml"
+      - ".github/workflows/publish-openai-agents.yml"
 
 jobs:
   test:

--- a/.github/workflows/publish-openai-agents.yml
+++ b/.github/workflows/publish-openai-agents.yml
@@ -7,22 +7,46 @@ on:
       - "sprites-openai-agents-v[0-9]+.[0-9]+.[0-9]+-*"
 
 jobs:
-  publish:
+  verify:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - run: python -m pip install --upgrade build
       - name: Set package version from tag
         working-directory: integrations/openai-agents
         run: |
           VERSION="${GITHUB_REF_NAME#sprites-openai-agents-v}"
           sed -i "s/version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e .
+      - run: python -m pip install -e 'integrations/openai-agents[dev]'
+      - run: python -m pytest integrations/openai-agents/tests
+      - run: python -m ruff check --config integrations/openai-agents/pyproject.toml integrations/openai-agents
+      - run: python -m mypy --config-file integrations/openai-agents/pyproject.toml integrations/openai-agents/src
       - run: python -m build integrations/openai-agents
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sprites-openai-agents-dist
+          path: integrations/openai-agents/dist/
+          if-no-files-found: error
+
+  publish:
+    needs: verify
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/sprites-openai-agents
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: sprites-openai-agents-dist
+          path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: integrations/openai-agents/dist/
+          packages-dir: dist/


### PR DESCRIPTION
## Summary

- Verify release artifacts before publishing.
- Publish through the protected PyPI environment with least-privilege permissions.

## Testing

- 90 unit tests
- Ruff
- mypy
- Package build