### PR TITLE
Add service environment and directory support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+- Added `env` and `dir` support when creating services and parsing service responses.
+
 ## 0.2.0
 
 - Updated the SDK for the current Sprites API response and request shapes.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ stream = sprite.create_service(
     cmd="python",
     args=["-m", "http.server", "8000"],
     http_port=8000,
+    env={"APP_ENV": "production"},
+    dir="/app",
 )
 for event in stream:
     print(event.type, event.data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sprites-py"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python SDK for the Sprites API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/sprites/__init__.py
+++ b/src/sprites/__init__.py
@@ -63,7 +63,7 @@ from .types import (
     DirEntry,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = [
     # Main classes

--- a/src/sprites/services.py
+++ b/src/sprites/services.py
@@ -98,6 +98,8 @@ def _parse_service_with_state(data: dict) -> ServiceWithState:
         args=data.get("args", []),
         needs=data.get("needs", []),
         http_port=data.get("http_port"),
+        env=data.get("env", {}),
+        dir=data.get("dir"),
         state=state,
     )
 
@@ -204,6 +206,9 @@ def create_service(
     needs: Optional[list[str]] = None,
     http_port: Optional[int] = None,
     duration: Optional[float] = None,
+    *,
+    env: Optional[dict[str, str]] = None,
+    dir: Optional[str] = None,
 ) -> ServiceStream:
     """Create or update a service.
 
@@ -215,6 +220,8 @@ def create_service(
         needs: Services this service depends on.
         http_port: HTTP port the service listens on.
         duration: Monitoring duration in seconds.
+        env: Environment variables for the service.
+        dir: Working directory for the service.
 
     Returns:
         A stream of service log events.
@@ -226,13 +233,17 @@ def create_service(
     if duration:
         url += f"?duration={duration}s"
 
-    payload = {"cmd": cmd}
+    payload: dict[str, object] = {"cmd": cmd}
     if args:
         payload["args"] = args
     if needs:
         payload["needs"] = needs
     if http_port is not None:
         payload["http_port"] = http_port
+    if env is not None:
+        payload["env"] = env
+    if dir is not None:
+        payload["dir"] = dir
 
     with httpx.Client(
         timeout=120.0,

--- a/src/sprites/sprite.py
+++ b/src/sprites/sprite.py
@@ -482,10 +482,23 @@ class Sprite:
         needs: Optional[List[str]] = None,
         http_port: Optional[int] = None,
         duration: Optional[float] = None,
+        *,
+        env: Optional[Dict[str, str]] = None,
+        dir: Optional[str] = None,
     ):
         """Create or update a service and return its log stream."""
         from .services import create_service
-        return create_service(self, service_name, cmd, args, needs, http_port, duration)
+        return create_service(
+            self,
+            service_name,
+            cmd,
+            args,
+            needs,
+            http_port,
+            duration,
+            env=env,
+            dir=dir,
+        )
 
     def start_service(self, service_name: str, duration: Optional[float] = None):
         """Start a service and return its log stream."""

--- a/src/sprites/types.py
+++ b/src/sprites/types.py
@@ -146,6 +146,8 @@ class Service:
     args: List[str] = field(default_factory=list)
     needs: List[str] = field(default_factory=list)
     http_port: Optional[int] = None
+    env: Dict[str, str] = field(default_factory=dict)
+    dir: Optional[str] = None
 
 
 @dataclass
@@ -173,6 +175,8 @@ class ServiceRequest:
     args: Optional[List[str]] = None
     needs: Optional[List[str]] = None
     http_port: Optional[int] = None
+    env: Optional[Dict[str, str]] = None
+    dir: Optional[str] = None
 
 
 @dataclass

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -161,6 +161,8 @@ def test_service_helpers_parse_api_array_shape() -> None:
                     "args": ["-m", "http.server"],
                     "needs": [],
                     "http_port": 8000,
+                    "env": {"APP_ENV": "production"},
+                    "dir": "/app",
                     "state": {
                         "name": "web",
                         "status": "running",
@@ -178,9 +180,24 @@ def test_service_helpers_parse_api_array_shape() -> None:
 
     assert len(services) == 1
     assert services[0].name == "web"
+    assert services[0].env == {"APP_ENV": "production"}
+    assert services[0].dir == "/app"
     assert services[0].state is not None
     assert services[0].state.status == "running"
     assert services[0].state.started_at is not None
+
+
+def test_service_helpers_default_omitted_env_and_dir() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/sprites/demo/services/web"
+        return httpx.Response(200, json={"name": "web", "cmd": "run"})
+
+    client = make_client(handler)
+
+    service = client.sprite("demo").get_service("web")
+
+    assert service.env == {}
+    assert service.dir is None
 
 
 def test_sprite_command_accepts_documented_tty_options() -> None:

--- a/tests/test_stream_public_api.py
+++ b/tests/test_stream_public_api.py
@@ -126,6 +126,8 @@ def test_create_start_and_stop_service_post_and_parse_streams(monkeypatch) -> No
             needs=["db"],
             http_port=8000,
             duration=1.5,
+            env={"APP_ENV": "test"},
+            dir="/app",
         )
     )
     start_events = list(sprite.start_service("web api", duration=2.0))
@@ -144,6 +146,8 @@ def test_create_start_and_stop_service_post_and_parse_streams(monkeypatch) -> No
                 "args": ["-m", "http.server"],
                 "needs": ["db"],
                 "http_port": 8000,
+                "env": {"APP_ENV": "test"},
+                "dir": "/app",
             }
         },
     )
@@ -157,3 +161,33 @@ def test_create_start_and_stop_service_post_and_parse_streams(monkeypatch) -> No
         "https://api.test/v1/sprites/demo%2Fname/services/web%20api/stop?timeout=3.0s",
         {},
     )
+
+
+def test_create_service_preserves_positional_duration_and_empty_env(monkeypatch) -> None:
+    captured = []
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def put(self, url, **kwargs):
+            captured.append((url, kwargs))
+            return httpx.Response(200, text='{"type":"exit","exit_code":0}\n')
+
+    monkeypatch.setattr(services_module.httpx, "Client", FakeClient)
+    sprite = SpritesClient("test-token", base_url="https://api.test").sprite("demo")
+
+    list(sprite.create_service("worker", "run", None, None, None, 2.5, env={}))
+
+    assert captured == [
+        (
+            "https://api.test/v1/sprites/demo/services/worker?duration=2.5s",
+            {"json": {"cmd": "run", "env": {}}},
+        )
+    ]


### PR DESCRIPTION
## Summary

- add keyword-only `env` and `dir` options to service creation while preserving positional `duration` compatibility
- serialize explicitly provided service environment and working directory values, including an empty environment
- parse the new fields into service response types with backward-compatible defaults
- update tests, README, changelog, and bump the package to 0.4.0

## User impact

SDK users can configure service environment variables and working directories through the Sprites API without constructing requests manually. Existing service creation calls remain compatible.