### PR TITLE
Require client-signals v0.4.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "httpx>=0.25.0",
     "websockets>=12.0",
     # Human-vs-agent client signals (Fly-Client-* headers + User-Agent suffix).
-    "client-signals>=0.4.1",
+    "client-signals>=0.4.4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- require `client-signals` v0.4.4 or newer
- pick up the reviewed Grok Build attribution marker

## User impact

New `sprites-py` installations consistently include the v0.4.4 client-signal marker table instead of accepting older versions that cannot recognize Grok Build.

## Testing

- resolved PyPI `client-signals==0.4.4`
- pytest: 87 passed, 1 skipped
- Ruff lint and formatting checks passed
- mypy passed
- source and wheel builds passed

## Deployment

No backend deployment is required. PyPI `client-signals` v0.4.4 is already public.
