### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.0
+
+- Reduced command completion latency by closing exec WebSockets immediately after the command finishes.
+- Updated `client-signals` to 0.4.4, including Grok agent detection.
+
 ## 0.4.0
 
 - Added `env` and `dir` support when creating services and parsing service responses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sprites-py"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python SDK for the Sprites API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/sprites/__init__.py
+++ b/src/sprites/__init__.py
@@ -63,7 +63,7 @@ from .types import (
     URLSettings,
 )
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 __all__ = [
     # Main classes


### PR DESCRIPTION
## Summary

- bump package and runtime version metadata to 0.5.0
- document the exec latency improvement and client-signals 0.4.4 upgrade

## User impact

The release reduces exec command completion latency and includes updated agent attribution with Grok detection.

## Deployment

After this PR merges, push the v0.5.0 tag from the merged main commit. The tag will trigger the trusted PyPI publishing workflow.

## Verification

- Ruff lint and formatting checks
- mypy
- pytest (87 passed, 1 skipped)
- Python package build