### PR TITLE
Distinguish exec transport failures from process exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Report command WebSocket closures without an exit status as `NetworkError`
+  instead of treating transport failures as successful exits or `ExecError: 1`.
+
 ## 0.5.0
 
 - Reduced command completion latency by closing exec WebSockets immediately after the command finishes.

--- a/src/sprites/control.py
+++ b/src/sprites/control.py
@@ -51,6 +51,7 @@ class OpConn:
         self.tty = tty
         self.closed = False
         self.exit_code = -1
+        self.received_exit = False
         self._done_event = asyncio.Event()
 
         # Output buffers
@@ -137,6 +138,7 @@ class OpConn:
                 # Store exit code but DON'T signal done yet
                 # Wait for op.complete message to ensure proper sequencing
                 self.exit_code = payload[0] if payload else 0
+                self.received_exit = True
 
     def handle_text(self, data: str) -> None:
         """Handle text message (session_info, notifications, etc.).
@@ -162,6 +164,7 @@ class OpConn:
         self.closed = True
         if exit_code is not None:
             self.exit_code = exit_code
+            self.received_exit = True
         self._done_event.set()
 
     def close(self) -> None:

--- a/src/sprites/exec.py
+++ b/src/sprites/exec.py
@@ -100,6 +100,7 @@ class Cmd:
 
         Raises:
             ExitError: If the command exits with non-zero status.
+            NetworkError: If the connection closes before an exit status arrives.
             TimeoutError: If the command times out.
         """
         code = self._run_sync()
@@ -116,6 +117,7 @@ class Cmd:
 
         Raises:
             ExitError: If the command exits with non-zero status.
+            NetworkError: If the connection closes before an exit status arrives.
             TimeoutError: If the command times out.
             RuntimeError: If stdout is already set.
         """
@@ -140,6 +142,7 @@ class Cmd:
 
         Raises:
             ExitError: If the command exits with non-zero status.
+            NetworkError: If the connection closes before an exit status arrives.
             TimeoutError: If the command times out.
             RuntimeError: If stdout or stderr is already set.
         """
@@ -225,6 +228,7 @@ def run(
 
     Raises:
         ExitError: If check=True and command returns non-zero.
+        NetworkError: If the connection closes before an exit status arrives.
         TimeoutError: If command times out.
     """
     cmd = Cmd(

--- a/src/sprites/websocket.py
+++ b/src/sprites/websocket.py
@@ -13,7 +13,7 @@ from websockets.exceptions import ConnectionClosed, InvalidStatus, InvalidStatus
 
 from sprites._signals import signal_headers
 from sprites._utils import quote_path_segment, websocket_base_url
-from sprites.exceptions import parse_api_error
+from sprites.exceptions import NetworkError, SpriteError, parse_api_error
 
 if TYPE_CHECKING:
     from sprites.exec import Cmd
@@ -46,6 +46,7 @@ class WSCommand:
         self.cmd = cmd
         self.ws: websockets.WebSocketClientProtocol | None = None
         self.exit_code = -1
+        self.received_exit = False
         self.started = False
         self.done = False
         self._is_attach = cmd.session_id is not None
@@ -53,6 +54,7 @@ class WSCommand:
         self._stdout_buffer: bytearray = bytearray()
         self._stderr_buffer: bytearray = bytearray()
         self._io_task: asyncio.Task[None] | None = None
+        self._io_error: NetworkError | None = None
         self._session_info_event = asyncio.Event()
 
     def _build_websocket_url(self) -> str:
@@ -181,30 +183,27 @@ class WSCommand:
                     break
 
         except ConnectionClosed as e:
-            # Check if this is a normal closure (code 1000)
-            # The websockets library can sometimes raise ConnectionClosed even for normal closures
-            if e.code == 1000:
-                # Normal closure - treat as success if no exit code received
-                if self.exit_code < 0:
-                    self.exit_code = 0
-            else:
-                # Non-normal closure - treat as error
-                error_msg = (
-                    f"WebSocket ConnectionClosed: code={e.code}, reason={e.reason}\n"
-                )
-                self._stderr_buffer.extend(error_msg.encode())
-                if self.exit_code < 0:
-                    self.exit_code = 1
+            if not self.received_exit:
+                close = getattr(e, "rcvd", None)
+                if close is not None:
+                    code = close.code
+                    reason = close.reason
+                else:
+                    # Compatibility with websockets versions before ``rcvd``.
+                    code = getattr(e, "code", None)
+                    reason = getattr(e, "reason", None)
+                self._io_error = self._closed_before_exit_error(code, reason)
         except Exception as e:
-            # Any other exception - treat as error
-            error_msg = f"WebSocket I/O error: {type(e).__name__}: {e}\n"
-            self._stderr_buffer.extend(error_msg.encode())
-            if self.exit_code < 0:
-                self.exit_code = 1
+            if not self.received_exit:
+                self._io_error = NetworkError(
+                    f"WebSocket I/O failed before receiving command exit status: "
+                    f"{type(e).__name__}: {e}"
+                )
         else:
-            # Loop completed normally (connection closed with code 1000)
-            if self.exit_code < 0:
-                self.exit_code = 0
+            if not self.received_exit:
+                code = getattr(self.ws, "close_code", None)
+                reason = getattr(self.ws, "close_reason", None)
+                self._io_error = self._closed_before_exit_error(code, reason)
         finally:
             self.done = True
             # Clean up stdin task
@@ -254,6 +253,7 @@ class WSCommand:
                     self.cmd.stderr.write(payload)
             elif stream_id == StreamID.EXIT:
                 self.exit_code = payload[0] if payload else 0
+                self.received_exit = True
                 # Mark as done - the connection will close and loop will exit
                 self.done = True
 
@@ -264,6 +264,10 @@ class WSCommand:
             if info.get("type") == "session_info":
                 self.cmd.tty = info.get("tty", False)
                 self._session_info_event.set()
+            elif info.get("type") == "exit":
+                self.exit_code = info.get("exit_code", 0)
+                self.received_exit = True
+                self.done = True
         except json.JSONDecodeError:
             pass
 
@@ -319,17 +323,30 @@ class WSCommand:
             try:
                 await self._io_task
             except Exception as e:
-                # Task failed unexpectedly
-                error_msg = f"WebSocket task failed: {type(e).__name__}: {e}\n"
-                self._stderr_buffer.extend(error_msg.encode())
-                if self.exit_code < 0:
-                    self.exit_code = 1
-        # Safeguard: exit_code should never be -1 at this point
-        if self.exit_code < 0:
-            error_msg = "WebSocket error: exit code not set\n"
-            self._stderr_buffer.extend(error_msg.encode())
-            self.exit_code = 1
+                raise NetworkError(
+                    f"WebSocket task failed before receiving command exit status: "
+                    f"{type(e).__name__}: {e}"
+                ) from e
+        if not self.received_exit:
+            if self._io_error is not None:
+                raise self._io_error
+            raise NetworkError(
+                "WebSocket finished before receiving command exit status"
+            )
         return self.exit_code
+
+    @staticmethod
+    def _closed_before_exit_error(code: int | None, reason: str | None) -> NetworkError:
+        """Build an error for a close without the protocol's EXIT message."""
+        details = []
+        if code is not None:
+            details.append(f"code={code}")
+        if reason is not None:
+            details.append(f"reason={reason!r}")
+        suffix = f" ({', '.join(details)})" if details else ""
+        return NetworkError(
+            "WebSocket closed before receiving command exit status" + suffix
+        )
 
     async def close(self) -> None:
         """Close the WebSocket connection."""
@@ -359,32 +376,7 @@ async def run_ws_command(cmd: Cmd) -> int:
     if cmd.session_id is None and cmd.sprite.use_control_mode():
         return await run_ws_command_via_control(cmd)
 
-    ws_cmd = WSCommand(cmd)
-    ws_cmd.text_message_handler = cmd._text_message_handler
-
-    try:
-        await ws_cmd.start()
-        exit_code = await ws_cmd.wait()
-    except Exception as e:
-        # If connection or I/O fails, store error message in stderr buffer
-        # and return error exit code
-        error_msg = f"WebSocket error: {type(e).__name__}: {e}\n"
-        ws_cmd._stderr_buffer.extend(error_msg.encode())
-        exit_code = 1
-    finally:
-        # Ensure connection is closed
-        await ws_cmd.close()
-
-    # Copy buffered output if cmd is capturing
-    if cmd._capture_stdout:
-        cmd._stdout_data = ws_cmd.get_stdout()
-    if cmd._capture_stderr:
-        cmd._stderr_data = ws_cmd.get_stderr()
-    # Always copy stderr on error for debugging, even if not explicitly capturing
-    elif exit_code != 0:
-        cmd._stderr_data = ws_cmd.get_stderr()
-
-    return exit_code
+    return await _run_ws_command_direct(cmd)
 
 
 async def _run_ws_command_direct(cmd: Cmd) -> int:
@@ -398,26 +390,28 @@ async def _run_ws_command_direct(cmd: Cmd) -> int:
     """
     ws_cmd = WSCommand(cmd)
     ws_cmd.text_message_handler = cmd._text_message_handler
+    exit_code: int | None = None
 
     try:
         await ws_cmd.start()
         exit_code = await ws_cmd.wait()
+        return exit_code
+    except SpriteError:
+        raise
     except Exception as e:
-        error_msg = f"WebSocket error: {type(e).__name__}: {e}\n"
-        ws_cmd._stderr_buffer.extend(error_msg.encode())
-        exit_code = 1
+        raise NetworkError(f"WebSocket command failed: {type(e).__name__}: {e}") from e
     finally:
-        await ws_cmd.close()
-
-    # Copy buffered output if cmd is capturing
-    if cmd._capture_stdout:
-        cmd._stdout_data = ws_cmd.get_stdout()
-    if cmd._capture_stderr:
-        cmd._stderr_data = ws_cmd.get_stderr()
-    elif exit_code != 0:
-        cmd._stderr_data = ws_cmd.get_stderr()
-
-    return exit_code
+        try:
+            await ws_cmd.close()
+        except Exception:
+            # The command result is determined by the EXIT frame. A close
+            # handshake failure after that must not replace the result.
+            pass
+        finally:
+            if cmd._capture_stdout:
+                cmd._stdout_data = ws_cmd.get_stdout()
+            if cmd._capture_stderr or (exit_code is not None and exit_code != 0):
+                cmd._stderr_data = ws_cmd.get_stderr()
 
 
 async def run_ws_command_via_control(cmd: Cmd) -> int:
@@ -480,11 +474,18 @@ async def run_ws_command_via_control(cmd: Cmd) -> int:
             await op.send_eof()
 
         # Wait for operation to complete
-        exit_code = await op.wait()
+        try:
+            exit_code = await op.wait()
+        finally:
+            # Preserve any output received before a transport failure.
+            cmd._stdout_data = op.get_stdout()
+            cmd._stderr_data = op.get_stderr()
 
-        # Copy output
-        cmd._stdout_data = op.get_stdout()
-        cmd._stderr_data = op.get_stderr()
+        if not op.received_exit:
+            detail = f": {cc.close_error}" if cc.close_error is not None else ""
+            raise NetworkError(
+                "Control WebSocket closed before receiving command exit status" + detail
+            )
 
         return exit_code
 
@@ -499,11 +500,12 @@ async def run_ws_command_via_control(cmd: Cmd) -> int:
         # Retry with direct WebSocket
         return await _run_ws_command_direct(cmd)
 
+    except SpriteError:
+        raise
     except Exception as e:
-        # If control mode fails for other reasons, store error message in stderr buffer
-        error_msg = f"Control mode error: {type(e).__name__}: {e}\n"
-        cmd._stderr_data = error_msg.encode()
-        return 1
+        raise NetworkError(
+            f"Control WebSocket command failed: {type(e).__name__}: {e}"
+        ) from e
     finally:
         # Always release the connection back to the pool
         if cc is not None:

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,7 +1,44 @@
 """Tests for the control connection module."""
 
+import pytest
+
 from sprites import SpritesClient
 from sprites._utils import quote_path_segment, websocket_base_url
+from sprites.control import OpConn, StreamID
+
+
+class StubControlConnection:
+    """Minimal parent connection for testing operation state."""
+
+
+@pytest.mark.asyncio
+async def test_op_conn_distinguishes_exit_from_connection_close() -> None:
+    op = OpConn(StubControlConnection())  # type: ignore[arg-type]
+
+    op.close()
+
+    assert op.received_exit is False
+    assert op.get_exit_code() == -1
+
+
+@pytest.mark.asyncio
+async def test_op_conn_records_received_exit() -> None:
+    op = OpConn(StubControlConnection())  # type: ignore[arg-type]
+
+    op.handle_data(bytes([StreamID.EXIT, 4]))
+
+    assert op.received_exit is True
+    assert op.get_exit_code() == 4
+
+
+@pytest.mark.asyncio
+async def test_op_conn_completion_status_counts_as_received_exit() -> None:
+    op = OpConn(StubControlConnection())  # type: ignore[arg-type]
+
+    op.complete(0)
+
+    assert op.received_exit is True
+    assert op.get_exit_code() == 0
 
 
 class TestControlModeClientOptions:

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,159 @@
+"""Regression tests for command WebSocket completion semantics."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Union
+
+import pytest
+from websockets.exceptions import ConnectionClosedError
+from websockets.frames import Close
+
+from sprites import ExecError, NetworkError, SpritesClient
+from sprites.websocket import StreamID
+
+Message = Union[str, bytes, BaseException]
+
+
+class FakeWebSocket:
+    """Small async-iterator stand-in for a connected WebSocket."""
+
+    def __init__(
+        self,
+        messages: list[Message],
+        *,
+        close_code: int = 1000,
+        close_reason: str = "",
+    ) -> None:
+        self._messages: Iterator[Message] = iter(messages)
+        self.close_code = close_code
+        self.close_reason = close_reason
+        self.sent: list[bytes] = []
+        self.closed = False
+
+    def __aiter__(self) -> "FakeWebSocket":
+        return self
+
+    async def __anext__(self) -> str | bytes:
+        try:
+            message = next(self._messages)
+        except StopIteration:
+            raise StopAsyncIteration from None
+        if isinstance(message, BaseException):
+            raise message
+        return message
+
+    async def send(self, data: bytes) -> None:
+        self.sent.append(data)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def command_with_websocket(
+    monkeypatch: pytest.MonkeyPatch,
+    websocket: FakeWebSocket,
+    *,
+    tty: bool = False,
+):
+    """Create a command whose WebSocket dial returns ``websocket``."""
+
+    async def connect(*args, **kwargs):
+        return websocket
+
+    monkeypatch.setattr("sprites.websocket.websockets.connect", connect)
+    client = SpritesClient("test-token", base_url="https://api.test")
+    return client.sprite("demo").command("echo", "test", tty=tty)
+
+
+def test_dial_failure_is_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def connect(*args, **kwargs):
+        raise OSError("host unreachable")
+
+    monkeypatch.setattr("sprites.websocket.websockets.connect", connect)
+    client = SpritesClient("test-token", base_url="https://api.test")
+    cmd = client.sprite("demo").command("echo", "test")
+
+    with pytest.raises(NetworkError, match="OSError: host unreachable"):
+        cmd.output()
+
+
+def test_normal_close_without_exit_is_network_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    websocket = FakeWebSocket(
+        [bytes([StreamID.STDOUT]) + b"partial output\n"],
+        close_code=1000,
+    )
+    cmd = command_with_websocket(monkeypatch, websocket)
+
+    with pytest.raises(
+        NetworkError,
+        match="closed before receiving command exit status.*code=1000",
+    ):
+        cmd.output()
+
+    assert cmd._stdout_data == b"partial output\n"
+    assert cmd._stderr_data == b""
+    assert websocket.closed is True
+
+
+def test_abnormal_close_without_exit_is_network_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    close = Close(1011, "abnormal")
+    websocket = FakeWebSocket(
+        [ConnectionClosedError(close, None)],
+        close_code=1011,
+        close_reason="abnormal",
+    )
+    cmd = command_with_websocket(monkeypatch, websocket)
+
+    with pytest.raises(
+        NetworkError,
+        match="code=1011.*reason='abnormal'",
+    ):
+        cmd.output()
+
+
+def test_nonzero_exit_frame_remains_exec_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    websocket = FakeWebSocket(
+        [
+            bytes([StreamID.STDERR]) + b"command failed\n",
+            bytes([StreamID.EXIT, 7]),
+        ]
+    )
+    cmd = command_with_websocket(monkeypatch, websocket)
+
+    with pytest.raises(ExecError) as exc_info:
+        cmd.output()
+
+    assert exc_info.value.exit_code() == 7
+    assert exc_info.value.stderr == b"command failed\n"
+
+
+def test_zero_exit_frame_returns_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    websocket = FakeWebSocket(
+        [
+            bytes([StreamID.STDOUT]) + b"test\n",
+            bytes([StreamID.EXIT, 0]),
+        ]
+    )
+    cmd = command_with_websocket(monkeypatch, websocket)
+
+    assert cmd.output() == b"test\n"
+
+
+def test_tty_exit_message_sets_process_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    websocket = FakeWebSocket([b"terminal output\n", '{"type":"exit","exit_code":3}'])
+    cmd = command_with_websocket(monkeypatch, websocket, tty=True)
+
+    with pytest.raises(ExecError) as exc_info:
+        cmd.output()
+
+    assert exc_info.value.exit_code() == 3
+    assert exc_info.value.stdout == b"terminal output\n"


### PR DESCRIPTION
## User impact

Command WebSocket failures no longer masquerade as successful exits or `ExecError: 1`. Callers now receive `NetworkError` when the connection closes before the server sends an EXIT status, while genuine nonzero process exits remain `ExecError`.

## Changes

- Track whether direct, TTY, and control-mode exec paths received an authoritative exit status.
- Preserve partial command output across ambiguous connection closures.
- Parse TTY exit messages and preserve real stderr on nonzero exits.
- Add regression coverage for normal-empty closes, abnormal closes, dial failures, TTY completion, and real exit codes.

## Scope

This fixes the client-side misclassification in #11 and makes the server-side race in #16 observable as a transport failure. It intentionally does not retry ambiguous commands because the command may have executed and automatic retry could duplicate side effects. The relay race that loses stdout/stderr and EXIT frames still requires a server fix, so this PR references rather than closes #16.

Fixes #11
Refs #16

## Verification

- `pytest`: 96 passed, 1 skipped
- `ruff check` and `ruff format --check`
- `mypy src`
- package sdist and wheel build

Deployment: publish a new Python SDK release; no server deployment is included.