### PR TITLE
Restore -log-target flag in test-cli arg parser

### DIFF
--- a/test_cli/main.py
+++ b/test_cli/main.py
@@ -149,6 +149,9 @@ def parse_args(argv: List[str]) -> tuple[Dict[str, Any], List[str]]:
         elif arg == "-env":
             i += 1
             options["env"] = argv[i]
+        elif arg == "-log-target":
+            i += 1
+            options["log_target"] = argv[i]
         elif arg == "-json":
             options["json"] = True
         elif arg in ("-help", "--help"):


### PR DESCRIPTION
## Problem

The SDK test harness in sprite-env adds the `-log-target` flag to each test-cli command. The argument parser in `test_cli/main.py` does not know this flag. The parser stops at the unknown flag. It reads the flag and all the words that follow as the command. The test-cli then shows this error: `Error: -sprite is required for exec commands`. The `TestTTY` test in the harness fails.

The first version of the test-cli had this flag. Commit 9cc6d17 replaced the parser and removed the flag. Branch `fix/test-cli-log-target` added the flag again, but the branch was not merged.

## Solution

This change adds the `-log-target` flag to the parser again. The change is a cherry-pick of commit d9a6b22 from branch `fix/test-cli-log-target`.

## Tests

The full sprite-env SDK test suite ran against the live API with this change. All the tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
