### PR TITLE
fix: migrate off deprecated websockets APIs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.25.0",
-    "websockets>=12.0",
+    "websockets>=14.0",
     # Human-vs-agent client signals (Fly-Client-* headers + User-Agent suffix).
     "client-signals>=0.4.4",
 ]

--- a/src/sprites/control.py
+++ b/src/sprites/control.py
@@ -7,7 +7,7 @@ import atexit
 import json
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
-import websockets
+from websockets.asyncio.client import ClientConnection, connect
 from websockets.exceptions import ConnectionClosed
 
 from sprites._signals import signal_headers
@@ -212,7 +212,7 @@ class ControlConnection:
             sprite: The sprite this connection is for
         """
         self.sprite = sprite
-        self.ws: websockets.WebSocketClientProtocol | None = None
+        self.ws: ClientConnection | None = None
         self.op_active = False
         self.op_conn: OpConn | None = None
         self.closed = False
@@ -232,7 +232,7 @@ class ControlConnection:
             **signal_headers(),
         }
 
-        self.ws = await websockets.connect(
+        self.ws = await connect(
             url,
             additional_headers=headers,
             ping_interval=WS_PING_INTERVAL,

--- a/src/sprites/control.py
+++ b/src/sprites/control.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
 from websockets.asyncio.client import ClientConnection, connect
 from websockets.exceptions import ConnectionClosed
+from websockets.protocol import State
 
 from sprites._signals import signal_headers
 from sprites._utils import quote_path_segment, websocket_base_url
@@ -377,7 +378,7 @@ class ControlConnection:
         Args:
             data: Data to send
         """
-        if self.ws is None or self.ws.state != websockets.protocol.State.OPEN:
+        if self.ws is None or self.ws.state != State.OPEN:
             raise RuntimeError("WebSocket not connected")
         await self.ws.send(data)
 
@@ -387,7 +388,7 @@ class ControlConnection:
         Args:
             data: Text to send
         """
-        if self.ws is None or self.ws.state != websockets.protocol.State.OPEN:
+        if self.ws is None or self.ws.state != State.OPEN:
             raise RuntimeError("WebSocket not connected")
         await self.ws.send(data)
 

--- a/src/sprites/websocket.py
+++ b/src/sprites/websocket.py
@@ -8,8 +8,8 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Callable
 from urllib.parse import urlencode
 
-import websockets
-from websockets.exceptions import ConnectionClosed, InvalidStatus, InvalidStatusCode
+from websockets.asyncio.client import ClientConnection, connect
+from websockets.exceptions import ConnectionClosed, InvalidStatus
 
 from sprites._signals import signal_headers
 from sprites._utils import quote_path_segment, websocket_base_url
@@ -44,7 +44,7 @@ class WSCommand:
             cmd: The Cmd instance to execute.
         """
         self.cmd = cmd
-        self.ws: websockets.WebSocketClientProtocol | None = None
+        self.ws: ClientConnection | None = None
         self.exit_code = -1
         self.received_exit = False
         self.started = False
@@ -112,7 +112,7 @@ class WSCommand:
         }
 
         try:
-            self.ws = await websockets.connect(
+            self.ws = await connect(
                 url,
                 additional_headers=headers,
                 ping_interval=WS_PING_INTERVAL,
@@ -126,17 +126,11 @@ class WSCommand:
                 # from ~5.3s to ~140ms (a ~38x speedup). See #24.
                 close_timeout=0,
             )
-        except InvalidStatusCode as e:
+        except InvalidStatus as e:
             # Try to parse as a structured API error
-            body = b""
-            response_headers: dict[str, str] = {}
-            if hasattr(e, "response") and e.response is not None:
-                # websockets >= 12.0 provides response object
-                if hasattr(e.response, "body"):
-                    body = e.response.body or b""
-                if hasattr(e.response, "headers"):
-                    response_headers = dict(e.response.headers)
-            api_err = parse_api_error(e.status_code, body, response_headers)
+            body = e.response.body or b""
+            response_headers = dict(e.response.headers)
+            api_err = parse_api_error(e.response.status_code, body, response_headers)
             if api_err is not None:
                 raise api_err from None
             # Fall back to original exception
@@ -489,7 +483,7 @@ async def run_ws_command_via_control(cmd: Cmd) -> int:
 
         return exit_code
 
-    except (InvalidStatusCode, InvalidStatus):
+    except InvalidStatus:
         # Control endpoint returned error (likely 404) - fall back to direct mode
         # Release connection if we got one
         if cc is not None:

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -61,7 +61,7 @@ def command_with_websocket(
     async def connect(*args, **kwargs):
         return websocket
 
-    monkeypatch.setattr("sprites.websocket.websockets.connect", connect)
+    monkeypatch.setattr("sprites.websocket.connect", connect)
     client = SpritesClient("test-token", base_url="https://api.test")
     return client.sprite("demo").command("echo", "test", tty=tty)
 
@@ -70,7 +70,7 @@ def test_dial_failure_is_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
     async def connect(*args, **kwargs):
         raise OSError("host unreachable")
 
-    monkeypatch.setattr("sprites.websocket.websockets.connect", connect)
+    monkeypatch.setattr("sprites.websocket.connect", connect)
     client = SpritesClient("test-token", base_url="https://api.test")
     cmd = client.sprite("demo").command("echo", "test")
 


### PR DESCRIPTION
## Problem

`sprites/websocket.py` imports `websockets.exceptions.InvalidStatusCode` and annotates connections as `websockets.WebSocketClientProtocol` (also in `control.py`). Both are deprecated legacy aliases in current `websockets` releases; the annotation lazily imports the deprecated `websockets.legacy` package. The resulting `DeprecationWarning`s break downstream test suites that turn warnings into errors.

## Fix

- Import `connect` and `ClientConnection` from `websockets.asyncio.client`; use `ClientConnection` for the connection attributes.
- Handle `InvalidStatus` (the modern exception) instead of `InvalidStatusCode`. Its `.response` always carries `status_code`, `headers`, and `body`, so the `hasattr` probing is gone.
- Raise the `websockets` floor to `>=14.0`. The code passes `additional_headers` to the top-level `connect`, which resolves to the modern asyncio client only from websockets 14 — so the effective floor was already 14 and the declared `>=12.0` was too loose.
- Update one test that monkeypatched `sprites.websocket.websockets.connect` to patch `sprites.websocket.connect`.

No behavior change: the structured API-error parsing on failed upgrades and the control-mode 404 fallback work as before.

## Tests

- 96 unit tests pass with `-W error::DeprecationWarning`.
- Live verification against the real API with `DeprecationWarning` promoted to error: a real exec over the websocket path passes, and a bad token surfaces a structured `APIError` through the `InvalidStatus` handler.