### PR TITLE
Prevent shutdown loop recreation and unbounded checkpoint waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,13 @@ for path in (fs / ".").iterdir():
 # List checkpoints
 checkpoints = sprite.list_checkpoints()
 
-# Create a checkpoint
+# Create a checkpoint (five-minute network inactivity timeout by default)
 stream = sprite.create_checkpoint("my checkpoint")
 for msg in stream:
     print(msg.type, msg.data)
 
-# Restore a checkpoint
-stream = sprite.restore_checkpoint("checkpoint-id")
+# Restore a checkpoint with a caller-selected timeout
+stream = sprite.restore_checkpoint("checkpoint-id", timeout=600)
 for msg in stream:
     print(msg.type, msg.data)
 ```

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -6,7 +6,9 @@
 
 # step: Setup client
 import os
+
 from sprites import SpritesClient
+
 client = SpritesClient(os.environ["SPRITE_TOKEN"])
 
 # step: Create a sprite
@@ -18,6 +20,7 @@ result = client.sprite(os.environ["SPRITE_NAME"]).run(
     "-c",
     "print(2+2)",
     capture_output=True,
+    timeout=30,
 )
 print(result.stdout.decode(), end="")
 

--- a/src/sprites/checkpoint.py
+++ b/src/sprites/checkpoint.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Iterator, Union
 
 import httpx
 
@@ -15,6 +15,9 @@ from sprites.types import Checkpoint, StreamMessage
 
 if TYPE_CHECKING:
     from sprites.sprite import Sprite
+
+
+CHECKPOINT_TIMEOUT = 300.0
 
 
 class CheckpointStream:
@@ -207,12 +210,19 @@ def get_checkpoint(sprite: Sprite, checkpoint_id: str) -> Checkpoint:
     )
 
 
-def create_checkpoint(sprite: Sprite, comment: str = "") -> CheckpointStream:
+def create_checkpoint(
+    sprite: Sprite,
+    comment: str = "",
+    *,
+    timeout: Union[float, httpx.Timeout] = CHECKPOINT_TIMEOUT,
+) -> CheckpointStream:
     """Create a new checkpoint.
 
     Args:
         sprite: The sprite to checkpoint.
         comment: Optional comment for the checkpoint.
+        timeout: HTTP timeout in seconds, or an httpx.Timeout configuration.
+            Defaults to five minutes.
 
     Returns:
         A stream of checkpoint creation messages.
@@ -226,9 +236,9 @@ def create_checkpoint(sprite: Sprite, comment: str = "") -> CheckpointStream:
     if comment:
         payload["comment"] = comment
 
-    # Use a separate client for streaming with no timeout
+    # Use a separate client because the response body contains checkpoint events.
     with httpx.Client(
-        timeout=None,
+        timeout=timeout,
         headers={**signal_headers(), "Authorization": f"Bearer {sprite.client.token}"},
     ) as client:
         try:
@@ -265,12 +275,19 @@ def create_checkpoint(sprite: Sprite, comment: str = "") -> CheckpointStream:
         return _MessageIterator(messages)
 
 
-def restore_checkpoint(sprite: Sprite, checkpoint_id: str) -> RestoreStream:
+def restore_checkpoint(
+    sprite: Sprite,
+    checkpoint_id: str,
+    *,
+    timeout: Union[float, httpx.Timeout] = CHECKPOINT_TIMEOUT,
+) -> RestoreStream:
     """Restore a checkpoint.
 
     Args:
         sprite: The sprite to restore.
         checkpoint_id: The ID of the checkpoint to restore.
+        timeout: HTTP timeout in seconds, or an httpx.Timeout configuration.
+            Defaults to five minutes.
 
     Returns:
         A stream of restore messages.
@@ -283,9 +300,9 @@ def restore_checkpoint(sprite: Sprite, checkpoint_id: str) -> RestoreStream:
         f"/checkpoints/{quote_path_segment(checkpoint_id)}/restore"
     )
 
-    # Use a separate client for streaming with no timeout
+    # Use a separate client because the response body contains restore events.
     with httpx.Client(
-        timeout=None,
+        timeout=timeout,
         headers={**signal_headers(), "Authorization": f"Bearer {sprite.client.token}"},
     ) as client:
         try:

--- a/src/sprites/control.py
+++ b/src/sprites/control.py
@@ -569,6 +569,16 @@ class ControlPool:
 
 # Module-level cache for control pools (one pool per sprite)
 _control_pools: Dict[str, ControlPool] = {}
+_cleanup_registered = False
+
+
+def _register_cleanup_on_exit() -> None:
+    """Register control cleanup after the persistent loop cleanup handler."""
+    global _cleanup_registered
+
+    if not _cleanup_registered:
+        atexit.register(_cleanup_on_exit)
+        _cleanup_registered = True
 
 
 async def get_control_connection(sprite: Sprite) -> ControlConnection:
@@ -585,6 +595,7 @@ async def get_control_connection(sprite: Sprite) -> ControlConnection:
     # Get or create pool
     if key not in _control_pools:
         _control_pools[key] = ControlPool(sprite)
+        _register_cleanup_on_exit()
 
     pool = _control_pools[key]
     return await pool.acquire()
@@ -651,9 +662,12 @@ def _cleanup_on_exit() -> None:
         return
 
     try:
-        from sprites.loop import get_loop, stop_loop
+        from sprites.loop import get_existing_loop, stop_loop
 
-        loop = get_loop()
+        loop = get_existing_loop()
+        if loop is None:
+            return
+
         future = asyncio.run_coroutine_threadsafe(_close_all_pools(), loop)
         future.result(timeout=5)
 
@@ -661,7 +675,3 @@ def _cleanup_on_exit() -> None:
         stop_loop()
     except Exception:
         pass  # Ignore errors during cleanup
-
-
-# Register cleanup handler
-atexit.register(_cleanup_on_exit)

--- a/src/sprites/loop.py
+++ b/src/sprites/loop.py
@@ -44,6 +44,18 @@ def get_loop() -> asyncio.AbstractEventLoop:
     return _loop
 
 
+def get_existing_loop() -> asyncio.AbstractEventLoop | None:
+    """Return the running persistent event loop without creating one.
+
+    Returns:
+        The persistent event loop if it exists and is running, otherwise None.
+    """
+    with _lock:
+        if _loop is None or not _loop.is_running():
+            return None
+        return _loop
+
+
 def run_sync(coro: Coroutine[Any, Any, T], timeout: float | None = None) -> T:
     """Run a coroutine synchronously using the persistent event loop.
 

--- a/src/sprites/sprite.py
+++ b/src/sprites/sprite.py
@@ -3,11 +3,12 @@ Sprite class representing a sprite instance
 """
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import httpx
 
 from ._utils import parse_sprite_info, quote_path_segment, sprite_base_url
+from .checkpoint import CHECKPOINT_TIMEOUT
 from .exceptions import (
     NetworkError,
     NotFoundError,
@@ -309,33 +310,47 @@ class Sprite:
             history=cp.get("history"),
         )
 
-    def create_checkpoint(self, comment: str = ""):
+    def create_checkpoint(
+        self,
+        comment: str = "",
+        *,
+        timeout: Union[float, httpx.Timeout] = CHECKPOINT_TIMEOUT,
+    ):
         """
         Create a new checkpoint.
 
         Args:
             comment: Optional comment for the checkpoint
+            timeout: HTTP timeout in seconds, or an httpx.Timeout configuration
+                (default: 300 seconds)
 
         Returns:
             Iterator of checkpoint creation messages
         """
         from .checkpoint import create_checkpoint
 
-        return create_checkpoint(self, comment)
+        return create_checkpoint(self, comment, timeout=timeout)
 
-    def restore_checkpoint(self, checkpoint_id: str):
+    def restore_checkpoint(
+        self,
+        checkpoint_id: str,
+        *,
+        timeout: Union[float, httpx.Timeout] = CHECKPOINT_TIMEOUT,
+    ):
         """
         Restore a checkpoint.
 
         Args:
             checkpoint_id: Checkpoint ID to restore
+            timeout: HTTP timeout in seconds, or an httpx.Timeout configuration
+                (default: 300 seconds)
 
         Returns:
             Iterator of restore messages
         """
         from .checkpoint import restore_checkpoint
 
-        return restore_checkpoint(self, checkpoint_id)
+        return restore_checkpoint(self, checkpoint_id, timeout=timeout)
 
     # ========== Command Execution API ==========
 

--- a/tests/test_loop_cleanup.py
+++ b/tests/test_loop_cleanup.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import sprites.control as control_module
+import sprites.loop as loop_module
+
+
+def test_control_cleanup_registers_lazily_on_first_pool(monkeypatch) -> None:
+    registered = []
+    connection = object()
+
+    class FakePool:
+        def __init__(self, sprite) -> None:
+            self.sprite = sprite
+
+        async def acquire(self):
+            return connection
+
+    sprite = SimpleNamespace(
+        name="demo",
+        client=SimpleNamespace(base_url="https://api.test"),
+    )
+    monkeypatch.setattr(control_module, "_control_pools", {})
+    monkeypatch.setattr(control_module, "_cleanup_registered", False)
+    monkeypatch.setattr(control_module, "ControlPool", FakePool)
+    monkeypatch.setattr(control_module.atexit, "register", registered.append)
+
+    first = asyncio.run(control_module.get_control_connection(sprite))
+    second = asyncio.run(control_module.get_control_connection(sprite))
+
+    assert first is connection
+    assert second is connection
+    assert registered == [control_module._cleanup_on_exit]
+
+
+def test_get_existing_loop_never_creates_a_loop(monkeypatch) -> None:
+    monkeypatch.setattr(loop_module, "_loop", None)
+
+    def fail_new_event_loop():
+        raise AssertionError("get_existing_loop() created an event loop")
+
+    monkeypatch.setattr(loop_module.asyncio, "new_event_loop", fail_new_event_loop)
+
+    assert loop_module.get_existing_loop() is None
+
+
+def test_control_cleanup_does_not_recreate_a_stopped_loop(monkeypatch) -> None:
+    monkeypatch.setattr(loop_module, "_loop", None)
+    monkeypatch.setattr(loop_module, "_thread", None)
+    monkeypatch.setattr(control_module, "_control_pools", {"remaining": object()})
+
+    def fail_get_loop():
+        raise AssertionError("control cleanup called the creating loop accessor")
+
+    def fail_new_event_loop():
+        raise AssertionError("control cleanup created an event loop")
+
+    def fail_thread(*args, **kwargs):
+        raise AssertionError("control cleanup created a thread")
+
+    monkeypatch.setattr(loop_module, "get_loop", fail_get_loop)
+    monkeypatch.setattr(loop_module.asyncio, "new_event_loop", fail_new_event_loop)
+    monkeypatch.setattr(loop_module.threading, "Thread", fail_thread)
+
+    control_module._cleanup_on_exit()
+
+    assert loop_module._loop is None
+    assert loop_module._thread is None
+
+
+def test_control_cleanup_closes_pools_while_loop_is_running(monkeypatch) -> None:
+    class FakePool:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    pool = FakePool()
+    pools = {"remaining": pool}
+    monkeypatch.setattr(control_module, "_control_pools", pools)
+
+    loop = loop_module.get_loop()
+    assert loop.is_running()
+
+    control_module._cleanup_on_exit()
+
+    assert pool.closed is True
+    assert pools == {}
+    assert loop_module.get_existing_loop() is None

--- a/tests/test_stream_public_api.py
+++ b/tests/test_stream_public_api.py
@@ -31,6 +31,7 @@ def test_create_and_restore_checkpoint_post_and_parse_streams(
     monkeypatch,
 ) -> None:
     captured = []
+    client_kwargs = []
     responses = [
         httpx.Response(
             200, text='{"type":"progress","data":"saving"}\n{"type":"done"}\n'
@@ -44,6 +45,7 @@ def test_create_and_restore_checkpoint_post_and_parse_streams(
         def __init__(self, *args, **kwargs):
             self.args = args
             self.kwargs = kwargs
+            client_kwargs.append(kwargs)
 
         def __enter__(self):
             return self
@@ -55,16 +57,20 @@ def test_create_and_restore_checkpoint_post_and_parse_streams(
             captured.append((url, kwargs))
             return responses.pop(0)
 
-    monkeypatch.setattr(checkpoint_module.httpx, "Client", FakeClient)
     sprite = SpritesClient("test-token", base_url="https://api.test").sprite(
         "demo/name"
     )
+    monkeypatch.setattr(checkpoint_module.httpx, "Client", FakeClient)
 
     create_messages = list(sprite.create_checkpoint("before upgrade"))
     restore_messages = list(sprite.restore_checkpoint("checkpoint one"))
 
     assert [message.type for message in create_messages] == ["progress", "done"]
     assert [message.type for message in restore_messages] == ["progress", "done"]
+    assert [kwargs["timeout"] for kwargs in client_kwargs] == [
+        checkpoint_module.CHECKPOINT_TIMEOUT,
+        checkpoint_module.CHECKPOINT_TIMEOUT,
+    ]
     assert captured[0] == (
         "https://api.test/v1/sprites/demo%2Fname/checkpoint",
         {
@@ -76,6 +82,31 @@ def test_create_and_restore_checkpoint_post_and_parse_streams(
         "https://api.test/v1/sprites/demo%2Fname/checkpoints/checkpoint%20one/restore",
         {},
     )
+
+
+def test_checkpoint_timeouts_can_be_configured(monkeypatch) -> None:
+    timeouts = []
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            timeouts.append(kwargs["timeout"])
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def post(self, url, **kwargs):
+            return httpx.Response(200, text='{"type":"done"}\n')
+
+    sprite = SpritesClient("test-token", base_url="https://api.test").sprite("demo")
+    monkeypatch.setattr(checkpoint_module.httpx, "Client", FakeClient)
+
+    list(sprite.create_checkpoint(timeout=12.5))
+    list(sprite.restore_checkpoint("checkpoint-id", timeout=45.0))
+
+    assert timeouts == [12.5, 45.0]
 
 
 def test_service_stream_process_all() -> None:


### PR DESCRIPTION
## Summary
- register control-pool cleanup lazily so it runs before persistent-loop teardown
- inspect the existing persistent loop during shutdown without creating a replacement
- apply a shared five-minute HTTP inactivity timeout to checkpoint create and restore, with caller overrides
- add focused shutdown and checkpoint timeout regressions
- demonstrate a finite command timeout in the quickstart

## User impact
Control WebSockets now receive graceful close frames during normal interpreter shutdown without risking a newly-created background loop. Stalled checkpoint requests no longer wait forever by default, while long-running checkpoints can continue as long as the server remains active and callers can select a different timeout.

## Deployment
No special deployment steps are required. This is an SDK-only behavior change and remains compatible with existing checkpoint calls.

## Testing
- uv run pytest: 101 passed
- uv run ruff check src tests examples
- git diff --check

Closes #35