### PR TITLE
Prepare v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,20 @@
 
 ## Unreleased
 
-- Report command WebSocket closures without an exit status as `NetworkError`
-  instead of treating transport failures as successful exits or `ExecError: 1`.
+## 0.6.0
+
+- Added configurable five-minute timeouts for checkpoint creation and restore
+  operations.
+- Fixed shutdown cleanup so it does not create a new event loop or thread.
+- Migrated command WebSocket handling off deprecated `websockets` APIs and
+  raised the minimum supported `websockets` version to 14.
 - Moved the separately published OpenAI Agents sandbox integration to
   [superfly/sprites-openai-agents](https://github.com/superfly/sprites-openai-agents).
+
+## 0.5.1
+
+- Report command WebSocket closures without an exit status as `NetworkError`
+  instead of treating transport failures as successful exits or `ExecError: 1`.
 
 ## 0.5.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sprites-py"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python SDK for Fly.io Sprites: computers for agents. Sprite management, remote command execution, filesystems, checkpoints, services, and network policy from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/sprites/__init__.py
+++ b/src/sprites/__init__.py
@@ -63,7 +63,7 @@ from .types import (
     URLSettings,
 )
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 __all__ = [
     # Main classes


### PR DESCRIPTION
## Summary

- move the shipped WebSocket-close fix into a 0.5.1 changelog section
- document the checkpoint timeout, shutdown cleanup, WebSocket migration, and integration move for 0.6.0
- update the source and package version to 0.6.0

## User impact

This prepares the Python SDK release that adds bounded, configurable checkpoint timeouts, avoids creating event-loop resources during shutdown, and supports the current websockets APIs.

## Deployment

After this merges, push tag v0.6.0. The tag-triggered publish workflow will build and upload sprites-py 0.6.0 to PyPI.

## Testing

- ruff check and format check
- mypy
- pytest: 101 passed
- built sprites_py-0.6.0 sdist and wheel
