### PR TITLE
Add native async/await support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Added native asyncio support through `AsyncSpritesClient` and matching async
+  sprite, command, and filesystem handles.
+- Fixed synchronous `Cmd.exit_code` to report the completed command's exit
+  status instead of remaining `-1`.
+
 ## 0.6.0
 
 - Added configurable five-minute timeouts for checkpoint creation and restore

--- a/README.md
+++ b/README.md
@@ -34,6 +34,35 @@ sprite.destroy()
 
 ## API Overview
 
+### Async API
+
+Async applications can use the matching native asyncio client. Its network
+operations use `httpx.AsyncClient`, and command execution runs directly on the
+caller's event loop.
+
+```python
+from sprites import AsyncSpritesClient
+
+async with AsyncSpritesClient(token="your-token") as client:
+    sprite = await client.create_sprite("my-sprite")
+
+    output = await sprite.command("echo", "hello").output()
+    result = await sprite.run("uname", "-a", capture_output=True)
+
+    config = sprite.filesystem("/app") / "config.json"
+    await config.write_text('{"debug": true}')
+    print(await config.read_text())
+
+    async for path in (sprite.filesystem("/app") / ".").iterdir():
+        print(path.name)
+
+    await sprite.destroy()
+```
+
+`AsyncSpritesClient` deliberately returns distinct `AsyncSprite`, `AsyncCmd`,
+and `AsyncSpritePath` objects. This keeps every I/O method predictably
+awaitable while preserving the existing synchronous API unchanged.
+
 ### SpritesClient
 
 ```python

--- a/src/sprites/__init__.py
+++ b/src/sprites/__init__.py
@@ -21,6 +21,10 @@ Usage:
         print(entry.name)
 """
 
+from .async_client import AsyncSpritesClient
+from .async_exec import AsyncCmd
+from .async_filesystem import AsyncSpriteFilesystem, AsyncSpritePath
+from .async_sprite import AsyncSprite
 from .client import SpritesClient
 from .control import ControlConnection, OpConn
 from .exceptions import (
@@ -68,9 +72,14 @@ __version__ = "0.6.0"
 __all__ = [
     # Main classes
     "SpritesClient",
+    "AsyncSpritesClient",
     "Sprite",
+    "AsyncSprite",
     "SpriteFilesystem",
+    "AsyncSpriteFilesystem",
     "SpritePath",
+    "AsyncSpritePath",
+    "AsyncCmd",
     "ControlConnection",
     "OpConn",
     # Exceptions

--- a/src/sprites/_interfaces.py
+++ b/src/sprites/_interfaces.py
@@ -1,0 +1,29 @@
+"""Internal structural types shared by sync and async implementations."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ClientLike(Protocol):
+    """Client attributes used by sprite transports."""
+
+    token: str
+    base_url: str
+    control_mode: bool
+
+
+class SpriteLike(Protocol):
+    """Sprite attributes used by command and control transports."""
+
+    name: str
+    _control_mode_supported: bool
+
+    @property
+    def client(self) -> ClientLike:
+        """Return the client that owns this sprite handle."""
+        ...
+
+    def use_control_mode(self) -> bool:
+        """Return whether multiplexed control transport should be used."""
+        ...

--- a/src/sprites/_path.py
+++ b/src/sprites/_path.py
@@ -1,0 +1,163 @@
+"""Pure path manipulation shared by sync and async filesystem handles."""
+
+from __future__ import annotations
+
+import posixpath
+from typing import Any, Generic, List, Protocol, TypeVar, Union, cast
+
+
+class _WorkingDirFilesystem(Protocol):
+    _working_dir: str
+
+
+PathT = TypeVar("PathT", bound="_SpritePathBase[Any, Any]")
+FilesystemT = TypeVar("FilesystemT", bound=_WorkingDirFilesystem)
+PathOperand = Union[str, "_SpritePathBase[Any, Any]"]
+
+
+class _SpritePathBase(Generic[PathT, FilesystemT]):
+    """Path operations that do not perform remote I/O."""
+
+    def __init__(self, filesystem: FilesystemT, path: str):
+        self._fs = filesystem
+        self._path = self._normalize_path(path)
+
+    def _normalize_path(self, path: str) -> str:
+        """Normalize a path against the filesystem working directory."""
+        if not path:
+            path = "."
+        if not path.startswith("/"):
+            if self._fs._working_dir == "/":
+                path = "/" + path
+            else:
+                path = posixpath.join(self._fs._working_dir, path)
+        return posixpath.normpath(path)
+
+    def _new(self, path: str) -> PathT:
+        """Create another path with the same concrete type and filesystem."""
+        return cast(PathT, type(self)(self._fs, path))
+
+    def __truediv__(self, other: PathOperand) -> PathT:
+        """Join this path with another path component."""
+        other_path = other._path if isinstance(other, _SpritePathBase) else str(other)
+        if other_path.startswith("/"):
+            return self._new(other_path)
+        return self._new(posixpath.join(self._path, other_path))
+
+    def __rtruediv__(self, other: str) -> PathT:
+        """Join a string path on the left of this path."""
+        return self._new(posixpath.join(other, self._path))
+
+    def __str__(self) -> str:
+        return self._path
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self._path!r})"
+
+    def __fspath__(self) -> str:
+        return self._path
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            type(self) is type(other)
+            and self._path == other._path
+            and self._fs is other._fs
+        )
+
+    def __hash__(self) -> int:
+        return hash(self._path)
+
+    @property
+    def name(self) -> str:
+        """Return the final path component."""
+        return posixpath.basename(self._path)
+
+    @property
+    def stem(self) -> str:
+        """Return the final component without its last suffix."""
+        dot_idx = self.name.rfind(".")
+        return self.name[:dot_idx] if dot_idx > 0 else self.name
+
+    @property
+    def suffix(self) -> str:
+        """Return the final component's last suffix."""
+        dot_idx = self.name.rfind(".")
+        return self.name[dot_idx:] if dot_idx > 0 else ""
+
+    @property
+    def suffixes(self) -> List[str]:
+        """Return all suffixes on the final path component."""
+        name = self.name[1:] if self.name.startswith(".") else self.name
+        parts = name.split(".")
+        return ["." + part for part in parts[1:]]
+
+    @property
+    def parent(self) -> PathT:
+        """Return the logical parent path."""
+        return self._new(posixpath.dirname(self._path) or "/")
+
+    @property
+    def parents(self) -> List[PathT]:
+        """Return all logical parents through the root."""
+        parents = []
+        current = self.parent
+        while current._path != "/" and current._path != self._path:
+            parents.append(current)
+            current = current.parent
+        if current._path == "/":
+            parents.append(current)
+        return parents
+
+    @property
+    def parts(self) -> tuple:
+        """Return the individual path components."""
+        if self._path == "/":
+            return ("/",)
+        parts = self._path.split("/")
+        if parts[0] == "":
+            parts[0] = "/"
+        return tuple(part for part in parts if part)
+
+    def is_absolute(self) -> bool:
+        """Return whether this path is absolute."""
+        return self._path.startswith("/")
+
+    def is_relative_to(self, other: PathOperand) -> bool:
+        """Return whether this path is within another path."""
+        other_path = other._path if isinstance(other, _SpritePathBase) else str(other)
+        return (
+            self._path.startswith(other_path.rstrip("/") + "/")
+            or self._path == other_path
+        )
+
+    def joinpath(self, *others: PathOperand) -> PathT:
+        """Combine this path with one or more path components."""
+        result = cast(PathT, self)
+        for other in others:
+            result = result / other
+        return result
+
+    def with_name(self, name: str) -> PathT:
+        """Return a path with the final component replaced."""
+        return self._new(posixpath.join(posixpath.dirname(self._path), name))
+
+    def with_stem(self, stem: str) -> PathT:
+        """Return a path with the final component's stem replaced."""
+        return self.with_name(stem + self.suffix)
+
+    def with_suffix(self, suffix: str) -> PathT:
+        """Return a path with the final component's suffix replaced."""
+        return self.with_name(self.stem + suffix)
+
+    def relative_to(self, other: PathOperand) -> PathT:
+        """Return this path relative to another path.
+
+        Raises:
+            ValueError: If this path is not within ``other``.
+        """
+        other_path = other._path if isinstance(other, _SpritePathBase) else str(other)
+        other_path = other_path.rstrip("/")
+        if not self._path.startswith(other_path + "/") and self._path != other_path:
+            raise ValueError(f"{self._path} is not relative to {other_path}")
+        relative = self._path[len(other_path) :].lstrip("/") or "."
+        return self._new(relative)

--- a/src/sprites/async_client.py
+++ b/src/sprites/async_client.py
@@ -1,0 +1,436 @@
+"""Asynchronous Sprites API client."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import httpx
+
+from ._signals import signal_headers
+from ._utils import parse_sprite_info, sprite_base_url
+from .client import _handle_response
+from .exceptions import NetworkError, SpriteError
+from .types import ListOptions, SpriteConfig, SpriteList, URLSettings
+
+if TYPE_CHECKING:
+    from .async_sprite import AsyncSprite
+
+
+class AsyncSpritesClient:
+    """Async client for the Sprites API.
+
+    This client owns an :class:`httpx.AsyncClient`; it does not call the sync
+    client or submit work to a thread pool.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        base_url: str = "https://api.sprites.dev",
+        timeout: float = 30.0,
+        control_mode: bool = False,
+    ):
+        """Initialize an async client.
+
+        Args:
+            token: Sprites API access token.
+            base_url: Base URL for the Sprites API.
+            timeout: Default HTTP request timeout in seconds.
+            control_mode: Enable multiplexed command WebSocket connections.
+        """
+        self.token = token
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.control_mode = control_mode
+        self._client = httpx.AsyncClient(timeout=timeout, headers=signal_headers())
+
+    async def __aenter__(self) -> "AsyncSpritesClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close this client's control pools and underlying HTTP client."""
+        from .control import close_control_pools
+
+        try:
+            await close_control_pools(self)
+        finally:
+            await self._client.aclose()
+
+    @property
+    def http_client(self) -> "_AsyncAuthenticatedClient":
+        """Return an async HTTP client that adds this client's token."""
+        return _AsyncAuthenticatedClient(self._client, self.token)
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
+
+    def _handle_response(self, response: httpx.Response, operation: str) -> None:
+        """Handle HTTP response errors consistently with the sync client."""
+        _handle_response(response, operation)
+
+    def _sprite_url(self, name: str) -> str:
+        return sprite_base_url(self.base_url, name)
+
+    def sprite(self, name: str) -> "AsyncSprite":
+        """Return an unfetched async sprite handle.
+
+        Args:
+            name: Sprite name.
+
+        Returns:
+            An async handle that performs no request until an I/O method is used.
+        """
+        from .async_sprite import AsyncSprite
+
+        return AsyncSprite(name, self)
+
+    async def create_sprite(
+        self,
+        name: str,
+        config: Optional[SpriteConfig] = None,
+        url_settings: Optional[URLSettings] = None,
+        labels: Optional[List[str]] = None,
+        wait_for_capacity: bool = False,
+        runtime: Optional[str] = None,
+    ) -> "AsyncSprite":
+        """Create a sprite and return its populated async handle.
+
+        Args:
+            name: Sprite name.
+            config: Optional machine configuration.
+            url_settings: Optional URL access settings.
+            labels: Labels to attach to the sprite.
+            wait_for_capacity: Wait for capacity instead of returning immediately.
+            runtime: Optional runtime variant.
+
+        Returns:
+            The newly created sprite.
+
+        Raises:
+            AuthenticationError: If the API token is rejected.
+            NetworkError: If the API request fails at the transport layer.
+            SpriteError: If the API returns another unsuccessful response.
+        """
+        request: Dict[str, Any] = {"name": name}
+        if config:
+            request["config"] = {
+                k: v
+                for k, v in {
+                    "ram_mb": config.ram_mb,
+                    "cpus": config.cpus,
+                    "region": config.region,
+                    "storage_gb": config.storage_gb,
+                }.items()
+                if v is not None
+            }
+        if url_settings:
+            request["url_settings"] = {
+                k: v
+                for k, v in {
+                    "auth": url_settings.auth,
+                    "private_access": url_settings.private_access,
+                }.items()
+                if v is not None
+            }
+        if labels is not None:
+            request["labels"] = labels
+        if wait_for_capacity:
+            request["wait_for_capacity"] = True
+        if runtime is not None:
+            request["runtime"] = runtime
+
+        try:
+            response = await self._client.post(
+                f"{self.base_url}/v1/sprites",
+                headers=self._headers(),
+                json=request,
+                timeout=120.0,
+            )
+        except httpx.RequestError as exc:
+            raise NetworkError(f"Network error creating sprite: {exc}") from exc
+
+        self._handle_response(response, "create sprite")
+        result = response.json()
+        sprite = self.sprite(result["name"])
+        sprite._update_from_info(result)
+        return sprite
+
+    async def get_sprite(self, name: str) -> "AsyncSprite":
+        """Fetch a sprite and return its populated async handle.
+
+        Args:
+            name: Sprite name.
+
+        Returns:
+            A sprite populated with the latest server metadata.
+
+        Raises:
+            NotFoundError: If the sprite does not exist.
+            NetworkError: If the API request fails at the transport layer.
+        """
+        try:
+            response = await self._client.get(
+                self._sprite_url(name), headers=self._headers()
+            )
+        except httpx.RequestError as exc:
+            raise NetworkError(f"Network error getting sprite: {exc}") from exc
+
+        self._handle_response(response, f"get sprite '{name}'")
+        info = response.json()
+        sprite = self.sprite(info["name"])
+        sprite._update_from_info(info)
+        return sprite
+
+    async def list_sprites(self, options: Optional[ListOptions] = None) -> SpriteList:
+        """List one page of sprites.
+
+        Args:
+            options: Optional filtering and pagination settings.
+
+        Returns:
+            A page of sprite metadata and continuation information.
+        """
+        params: Dict[str, Any] = {}
+        if options:
+            if options.max_results:
+                params["max_results"] = options.max_results
+            if options.continuation_token:
+                params["continuation_token"] = options.continuation_token
+            if options.prefix:
+                params["prefix"] = options.prefix
+            if options.bulk_load:
+                params["bulk_load"] = "true"
+
+        try:
+            response = await self._client.get(
+                f"{self.base_url}/v1/sprites",
+                headers=self._headers(),
+                params=params,
+            )
+        except httpx.RequestError as exc:
+            raise NetworkError(f"Network error listing sprites: {exc}") from exc
+
+        self._handle_response(response, "list sprites")
+        data = response.json()
+        return SpriteList(
+            sprites=[parse_sprite_info(item) for item in data.get("sprites", [])],
+            has_more=data.get("has_more", False),
+            next_continuation_token=data.get("next_continuation_token"),
+            running=data.get("running", 0),
+            warm=data.get("warm", 0),
+            cold=data.get("cold", 0),
+        )
+
+    async def list_all_sprites(
+        self, prefix: Optional[str] = None
+    ) -> List["AsyncSprite"]:
+        """List all sprites, following continuation tokens.
+
+        Args:
+            prefix: Optional sprite-name prefix.
+
+        Returns:
+            Unfetched async handles for every matching sprite.
+        """
+        sprites: List["AsyncSprite"] = []
+        continuation_token: Optional[str] = None
+        while True:
+            page = await self.list_sprites(
+                ListOptions(
+                    prefix=prefix,
+                    max_results=100,
+                    continuation_token=continuation_token,
+                )
+            )
+            sprites.extend(self.sprite(info.name) for info in page.sprites)
+            if not page.has_more:
+                return sprites
+            continuation_token = page.next_continuation_token
+
+    async def destroy_sprite(self, name: str) -> None:
+        """Destroy a sprite.
+
+        Args:
+            name: Sprite name.
+        """
+        try:
+            response = await self._client.delete(
+                self._sprite_url(name), headers=self._headers()
+            )
+        except httpx.RequestError as exc:
+            raise NetworkError(f"Network error deleting sprite: {exc}") from exc
+        if response.status_code != 204:
+            self._handle_response(response, f"destroy sprite '{name}'")
+
+    async def delete_sprite(self, name: str) -> None:
+        """Alias for :meth:`destroy_sprite`."""
+        await self.destroy_sprite(name)
+
+    async def upgrade_sprite(self, name: str) -> None:
+        """Upgrade a sprite to the latest version."""
+        try:
+            response = await self._client.post(
+                f"{self._sprite_url(name)}/upgrade",
+                headers=self._headers(),
+                timeout=60.0,
+            )
+        except httpx.RequestError as exc:
+            raise NetworkError(f"Network error upgrading sprite: {exc}") from exc
+        if response.status_code not in (200, 204):
+            self._handle_response(response, f"upgrade sprite '{name}'")
+
+    async def update_url_settings(self, name: str, settings: URLSettings) -> None:
+        """Update only a sprite's URL settings.
+
+        Args:
+            name: Sprite name.
+            settings: Replacement URL access settings.
+        """
+        await self._update_sprite_request(
+            name,
+            {
+                "url_settings": {
+                    k: v
+                    for k, v in {
+                        "auth": settings.auth,
+                        "private_access": settings.private_access,
+                    }.items()
+                    if v is not None
+                }
+            },
+            f"update URL settings for '{name}'",
+        )
+
+    async def update_sprite(
+        self,
+        name: str,
+        *,
+        url_settings: Optional[URLSettings] = None,
+        labels: Optional[List[str]] = None,
+    ) -> "AsyncSprite":
+        """Partially update mutable sprite settings.
+
+        Args:
+            name: Sprite name.
+            url_settings: Replacement URL access settings, when supplied.
+            labels: Replacement labels, when supplied.
+
+        Returns:
+            A populated handle containing the updated metadata.
+
+        Raises:
+            ValueError: If no mutable field is supplied.
+        """
+        if url_settings is None and labels is None:
+            raise ValueError("url_settings or labels is required")
+
+        body: Dict[str, Any] = {}
+        if url_settings is not None:
+            body["url_settings"] = {
+                k: v
+                for k, v in {
+                    "auth": url_settings.auth,
+                    "private_access": url_settings.private_access,
+                }.items()
+                if v is not None
+            }
+        if labels is not None:
+            body["labels"] = labels
+
+        response = await self._update_sprite_request(
+            name, body, f"update sprite '{name}'"
+        )
+        info = response.json()
+        sprite = self.sprite(info.get("name", name))
+        sprite._update_from_info(info)
+        return sprite
+
+    async def _update_sprite_request(
+        self, name: str, body: Dict[str, Any], operation: str
+    ) -> httpx.Response:
+        try:
+            response = await self._client.put(
+                self._sprite_url(name), headers=self._headers(), json=body
+            )
+        except httpx.RequestError as exc:
+            raise NetworkError(f"Network error updating sprite: {exc}") from exc
+        self._handle_response(response, operation)
+        return response
+
+    @staticmethod
+    async def create_token(
+        fly_macaroon: str, org_slug: str, invite_code: Optional[str] = None
+    ) -> str:
+        """Create a sprite access token without blocking the event loop.
+
+        Args:
+            fly_macaroon: Fly.io macaroon token.
+            org_slug: Fly.io organization slug.
+            invite_code: Optional Sprites invite code.
+
+        Returns:
+            The newly minted Sprites API token.
+
+        Raises:
+            NetworkError: If the token request fails at the transport layer.
+            SpriteError: If the API rejects the request or omits the token.
+        """
+        body: Dict[str, Any] = {"description": "Sprite SDK Token"}
+        if invite_code:
+            body["invite_code"] = invite_code
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            try:
+                response = await client.post(
+                    f"https://api.sprites.dev/v1/organizations/{org_slug}/tokens",
+                    headers={
+                        "Authorization": f"FlyV1 {fly_macaroon}",
+                        "Content-Type": "application/json",
+                    },
+                    json=body,
+                )
+            except httpx.RequestError as exc:
+                raise NetworkError(f"Network error creating token: {exc}") from exc
+        if not response.is_success:
+            raise SpriteError(
+                f"API returned status {response.status_code}: {response.text}"
+            )
+        result = response.json()
+        if "token" not in result:
+            raise SpriteError("No token returned in response")
+        token = result["token"]
+        if not isinstance(token, str):
+            raise SpriteError("Invalid token returned in response")
+        return token
+
+
+class _AsyncAuthenticatedClient:
+    """Add bearer authentication to an ``httpx.AsyncClient``."""
+
+    def __init__(self, client: httpx.AsyncClient, token: str):
+        self._client = client
+        self._token = token
+
+    def _kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        headers = kwargs.pop("headers", {}).copy()
+        headers["Authorization"] = f"Bearer {self._token}"
+        kwargs["headers"] = headers
+        return kwargs
+
+    async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+        return await self._client.get(url, **self._kwargs(kwargs))
+
+    async def post(self, url: str, **kwargs: Any) -> httpx.Response:
+        return await self._client.post(url, **self._kwargs(kwargs))
+
+    async def put(self, url: str, **kwargs: Any) -> httpx.Response:
+        return await self._client.put(url, **self._kwargs(kwargs))
+
+    async def delete(self, url: str, **kwargs: Any) -> httpx.Response:
+        return await self._client.delete(url, **self._kwargs(kwargs))

--- a/src/sprites/async_exec.py
+++ b/src/sprites/async_exec.py
@@ -1,0 +1,138 @@
+"""Native asyncio command execution for Sprites."""
+
+from __future__ import annotations
+
+from ._interfaces import SpriteLike
+from .exceptions import ExitError
+from .exec import CompletedProcess, _CmdBase
+
+
+class AsyncCmd(_CmdBase):
+    """An asynchronously executed command.
+
+    The command runs directly on the caller's active event loop. Instances are
+    created by :meth:`AsyncSprite.command` rather than constructed directly.
+    """
+
+    async def _execute(self) -> int:
+        if self._started:
+            raise RuntimeError("command already started")
+        self._started = True
+        try:
+            self._exit_code = await self._run_async()
+            return self._exit_code
+        finally:
+            self._finished = True
+
+    async def run(self) -> None:
+        """Start the command and wait for it to complete.
+
+        Raises:
+            ExitError: If the command exits with a non-zero status.
+            NetworkError: If the WebSocket fails before an exit status arrives.
+            TimeoutError: If the configured timeout expires.
+        """
+        code = await self._execute()
+        if code != 0:
+            raise ExitError(
+                f"exit status {code}", code, self._stdout_data, self._stderr_data
+            )
+
+    async def output(self) -> bytes:
+        """Run the command and return stdout.
+
+        Returns:
+            Bytes written to stdout.
+
+        Raises:
+            ExitError: If the command exits with a non-zero status.
+            RuntimeError: If stdout is already configured.
+        """
+        if self.stdout is not None:
+            raise RuntimeError("stdout already set")
+        self._capture_stdout = True
+        code = await self._execute()
+        if code != 0:
+            raise ExitError(
+                f"exit status {code}", code, self._stdout_data, self._stderr_data
+            )
+        return self._stdout_data
+
+    async def combined_output(self) -> bytes:
+        """Run the command and return stdout followed by stderr.
+
+        Returns:
+            Combined stdout and stderr bytes.
+
+        Raises:
+            ExitError: If the command exits with a non-zero status.
+            RuntimeError: If stdout or stderr is already configured.
+        """
+        if self.stdout is not None:
+            raise RuntimeError("stdout already set")
+        if self.stderr is not None:
+            raise RuntimeError("stderr already set")
+        self._capture_stdout = True
+        self._capture_stderr = True
+        code = await self._execute()
+        combined = self._stdout_data + self._stderr_data
+        if code != 0:
+            raise ExitError(f"exit status {code}", code, combined, b"")
+        return combined
+
+
+async def run(
+    sprite: SpriteLike,
+    *args: str,
+    capture_output: bool = False,
+    timeout: float | None = None,
+    check: bool = False,
+    env: dict[str, str] | None = None,
+    cwd: str | None = None,
+    tty: bool = False,
+    tty_rows: int = 24,
+    tty_cols: int = 80,
+) -> CompletedProcess:
+    """Run a command asynchronously, mirroring :func:`subprocess.run`.
+
+    Args:
+        sprite: Sprite on which to execute the command.
+        *args: Command and arguments.
+        capture_output: Capture stdout and stderr in the result.
+        timeout: Maximum execution time in seconds.
+        check: Raise :class:`ExitError` for a non-zero exit status.
+        env: Environment variables for the command.
+        cwd: Working directory for the command.
+        tty: Whether to allocate a pseudo-terminal.
+        tty_rows: Terminal height in rows.
+        tty_cols: Terminal width in columns.
+
+    Returns:
+        Completed command information.
+    """
+    cmd = AsyncCmd(
+        sprite,
+        list(args),
+        env=env,
+        cwd=cwd,
+        tty=tty,
+        tty_rows=tty_rows,
+        tty_cols=tty_cols,
+        timeout=timeout,
+    )
+    if capture_output:
+        cmd._capture_stdout = True
+        cmd._capture_stderr = True
+
+    code = await cmd._execute()
+    result = CompletedProcess(
+        args=list(args),
+        returncode=code,
+        stdout=cmd._stdout_data if capture_output else None,
+        stderr=cmd._stderr_data if capture_output else None,
+    )
+    if check and code != 0:
+        raise ExitError(
+            f"exit status {code}", code, result.stdout or b"", result.stderr or b""
+        )
+    return result

--- a/src/sprites/async_filesystem.py
+++ b/src/sprites/async_filesystem.py
@@ -1,0 +1,384 @@
+"""Async pathlib-like access to a sprite filesystem."""
+
+from __future__ import annotations
+
+import posixpath
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Union
+
+import httpx
+
+from ._path import _SpritePathBase
+from ._utils import sprite_base_url
+from .exceptions import (
+    FileNotFoundError_,
+    FilesystemError,
+    IsADirectoryError_,
+)
+from .filesystem import SpritePath, _handle_filesystem_error
+from .types import FileStat
+
+if TYPE_CHECKING:
+    from .async_sprite import AsyncSprite
+
+
+class AsyncSpritePath(_SpritePathBase["AsyncSpritePath", "AsyncSpriteFilesystem"]):
+    """A pathlib-like sprite path with awaitable remote I/O methods."""
+
+    def _build_url(self, endpoint: str) -> str:
+        sprite = self._fs._sprite
+        return f"{sprite_base_url(sprite.client.base_url, sprite.name)}/fs{endpoint}"
+
+    def _headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self._fs._sprite.client.token}"}
+
+    def _handle_error(self, response: httpx.Response, operation: str) -> None:
+        _handle_filesystem_error(response, operation, self._path)
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        operation: str,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        try:
+            response = await self._fs._sprite.client._client.request(
+                method,
+                self._build_url(endpoint),
+                headers=kwargs.pop("headers", self._headers()),
+                **kwargs,
+            )
+        except httpx.RequestError as exc:
+            raise FilesystemError(str(exc), operation, self._path) from exc
+        if not response.is_success:
+            self._handle_error(response, operation)
+        return response
+
+    def _params(self) -> Dict[str, str]:
+        return {"path": self._path, "workingDir": self._fs._working_dir}
+
+    async def exists(self) -> bool:
+        """Return whether the remote path exists."""
+        try:
+            await self.stat()
+            return True
+        except FileNotFoundError_:
+            return False
+
+    async def is_file(self) -> bool:
+        """Return whether the remote path is a regular file."""
+        try:
+            return not (await self.stat()).is_dir
+        except FileNotFoundError_:
+            return False
+
+    async def is_dir(self) -> bool:
+        """Return whether the remote path is a directory."""
+        try:
+            return (await self.stat()).is_dir
+        except FileNotFoundError_:
+            return False
+
+    async def stat(self) -> FileStat:
+        """Return remote file metadata.
+
+        Returns:
+            Metadata for the remote path.
+
+        Raises:
+            FileNotFoundError_: If the path does not exist.
+        """
+        response = await self._request("GET", "/list", "stat", params=self._params())
+        entries = response.json().get("entries", [])
+        if not entries:
+            raise FileNotFoundError_("stat", self._path)
+        entry = entries[0]
+        mod_time = datetime.now()
+        if entry.get("modTime"):
+            try:
+                mod_time = datetime.fromisoformat(
+                    entry["modTime"].replace("Z", "+00:00")
+                )
+            except (ValueError, AttributeError):
+                pass
+        return FileStat(
+            name=entry.get("name", posixpath.basename(self._path)),
+            path=entry.get("path", self._path),
+            size=entry.get("size", 0),
+            mode=entry.get("mode", "0644"),
+            mod_time=mod_time,
+            is_dir=entry.get("isDir", False),
+        )
+
+    async def read_bytes(self) -> bytes:
+        """Read and return the remote file as bytes."""
+        response = await self._request("GET", "/read", "read", params=self._params())
+        content: bytes = response.content
+        return content
+
+    async def read_text(self, encoding: str = "utf-8") -> str:
+        """Read and decode the remote file.
+
+        Args:
+            encoding: Text encoding used to decode the file.
+
+        Returns:
+            Decoded file contents.
+        """
+        return (await self.read_bytes()).decode(encoding)
+
+    async def write_bytes(
+        self, data: bytes, mode: int = 0o644, mkdir_parents: bool = True
+    ) -> None:
+        """Write bytes to the remote file.
+
+        Args:
+            data: Bytes to write.
+            mode: File permissions used when creating the file.
+            mkdir_parents: Create missing parent directories.
+        """
+        params = {
+            **self._params(),
+            "mode": f"{mode:04o}",
+            "mkdirParents": str(mkdir_parents).lower(),
+        }
+        headers = {**self._headers(), "Content-Type": "application/octet-stream"}
+        await self._request(
+            "PUT", "/write", "write", params=params, headers=headers, content=data
+        )
+
+    async def write_text(
+        self,
+        data: str,
+        encoding: str = "utf-8",
+        mode: int = 0o644,
+        mkdir_parents: bool = True,
+    ) -> None:
+        """Encode and write text to the remote file.
+
+        Args:
+            data: Text to write.
+            encoding: Text encoding used to encode the data.
+            mode: File permissions used when creating the file.
+            mkdir_parents: Create missing parent directories.
+        """
+        await self.write_bytes(data.encode(encoding), mode, mkdir_parents)
+
+    async def iterdir(self) -> AsyncIterator["AsyncSpritePath"]:
+        """Yield paths contained in this remote directory."""
+        response = await self._request("GET", "/list", "iterdir", params=self._params())
+        for entry in response.json().get("entries", []):
+            name = entry.get("name", "")
+            if name:
+                yield self._new(posixpath.join(self._path, name))
+
+    async def listdir(self) -> List[str]:
+        """Return names contained in this remote directory."""
+        return [path.name async for path in self.iterdir()]
+
+    async def mkdir(
+        self, mode: int = 0o755, parents: bool = False, exist_ok: bool = False
+    ) -> None:
+        """Create a remote directory.
+
+        Args:
+            mode: Directory permissions.
+            parents: Create missing parent directories.
+            exist_ok: Do not fail when the directory already exists.
+        """
+        if exist_ok:
+            try:
+                stat = await self.stat()
+                if stat.is_dir:
+                    return
+                raise FilesystemError(
+                    "exists but is not a directory", "mkdir", self._path
+                )
+            except FileNotFoundError_:
+                pass
+        keep_path = self / ".keep"
+        await keep_path.write_bytes(b"", mode=0o644, mkdir_parents=parents)
+        try:
+            await keep_path.unlink()
+        except FileNotFoundError_:
+            pass
+
+    async def unlink(self, missing_ok: bool = False) -> None:
+        """Remove a remote file.
+
+        Args:
+            missing_ok: Do not fail when the path does not exist.
+        """
+        params = {**self._params(), "recursive": "false"}
+        try:
+            await self._request("DELETE", "/delete", "unlink", params=params)
+        except FileNotFoundError_:
+            if not missing_ok:
+                raise
+
+    async def rmdir(self) -> None:
+        """Remove an empty remote directory."""
+        await self._request(
+            "DELETE",
+            "/delete",
+            "rmdir",
+            params={**self._params(), "recursive": "false"},
+        )
+
+    async def rmtree(self) -> None:
+        """Recursively remove a remote directory and its contents."""
+        await self._request(
+            "DELETE",
+            "/delete",
+            "rmtree",
+            params={**self._params(), "recursive": "true"},
+        )
+
+    def _target_path(self, target: Union[str, "AsyncSpritePath", SpritePath]) -> str:
+        if hasattr(target, "_path"):
+            return target._path
+        if target.startswith("/"):
+            return target
+        return posixpath.join(posixpath.dirname(self._path), target)
+
+    async def rename(
+        self, target: Union[str, "AsyncSpritePath", SpritePath]
+    ) -> "AsyncSpritePath":
+        """Rename this remote path.
+
+        Args:
+            target: Destination path.
+
+        Returns:
+            A handle for the destination path.
+        """
+        target_path = self._target_path(target)
+        await self._request(
+            "POST",
+            "/rename",
+            "rename",
+            json={
+                "source": self._path,
+                "dest": target_path,
+                "workingDir": self._fs._working_dir,
+            },
+        )
+        return self._new(target_path)
+
+    async def replace(
+        self, target: Union[str, "AsyncSpritePath", SpritePath]
+    ) -> "AsyncSpritePath":
+        """Rename this path, replacing the destination when supported."""
+        return await self.rename(target)
+
+    async def copy_to(
+        self,
+        target: Union[str, "AsyncSpritePath", SpritePath],
+        recursive: bool = True,
+    ) -> "AsyncSpritePath":
+        """Copy this remote path.
+
+        Args:
+            target: Destination path.
+            recursive: Copy directory contents recursively.
+
+        Returns:
+            A handle for the destination path.
+        """
+        target_path = self._target_path(target)
+        await self._request(
+            "POST",
+            "/copy",
+            "copy",
+            json={
+                "source": self._path,
+                "dest": target_path,
+                "workingDir": self._fs._working_dir,
+                "recursive": recursive,
+            },
+        )
+        return self._new(target_path)
+
+    async def chmod(self, mode: int, recursive: bool = False) -> None:
+        """Change remote path permissions.
+
+        Args:
+            mode: New permissions.
+            recursive: Apply permissions recursively.
+        """
+        await self._request(
+            "POST",
+            "/chmod",
+            "chmod",
+            json={
+                "path": self._path,
+                "workingDir": self._fs._working_dir,
+                "mode": f"{mode:04o}",
+                "recursive": recursive,
+            },
+        )
+
+    async def touch(self, mode: int = 0o644, exist_ok: bool = True) -> None:
+        """Create a remote file or update its modification time.
+
+        Args:
+            mode: Permissions used when creating the file.
+            exist_ok: Do not fail when the file already exists.
+        """
+        if await self.exists():
+            if not exist_ok:
+                raise FilesystemError("file exists", "touch", self._path, "EEXIST")
+            try:
+                await self.write_bytes(await self.read_bytes(), mode=mode)
+            except IsADirectoryError_:
+                pass
+        else:
+            await self.write_bytes(b"", mode=mode)
+
+
+class AsyncSpriteFilesystem:
+    """Filesystem factory for :class:`AsyncSpritePath` objects."""
+
+    def __init__(self, sprite: "AsyncSprite", working_dir: str = "/"):
+        """Initialize an async filesystem.
+
+        Args:
+            sprite: Sprite that owns the remote filesystem.
+            working_dir: Base directory for relative paths.
+        """
+        self._sprite = sprite
+        self._working_dir = working_dir.rstrip("/") or "/"
+
+    def _new_path(self, path: str) -> AsyncSpritePath:
+        return AsyncSpritePath(self, path)
+
+    def __truediv__(
+        self, path: Union[str, AsyncSpritePath, SpritePath]
+    ) -> AsyncSpritePath:
+        """Create a path relative to this filesystem."""
+        if hasattr(path, "_path"):
+            return self._new_path(path._path)
+        return self._new_path(path)
+
+    def __repr__(self) -> str:
+        return (
+            f"AsyncSpriteFilesystem(sprite={self._sprite.name!r}, "
+            f"working_dir={self._working_dir!r})"
+        )
+
+    @property
+    def root(self) -> AsyncSpritePath:
+        """Return the remote root path."""
+        return self._new_path("/")
+
+    @property
+    def cwd(self) -> AsyncSpritePath:
+        """Return the configured working-directory path."""
+        return self._new_path(self._working_dir)
+
+    def path(self, *parts: str) -> AsyncSpritePath:
+        """Create a path from one or more components."""
+        if not parts:
+            return self.cwd
+        return self._new_path(posixpath.join(*parts))

--- a/src/sprites/async_sprite.py
+++ b/src/sprites/async_sprite.py
@@ -1,0 +1,678 @@
+"""Asynchronous sprite handle."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+import httpx
+
+from ._utils import parse_sprite_info, quote_path_segment, sprite_base_url
+from .checkpoint import (
+    CHECKPOINT_TIMEOUT,
+    CheckpointStream,
+    RestoreStream,
+    _MessageIterator,
+)
+from .exceptions import APIError, NetworkError, NotFoundError, SpriteError
+from .services import ServiceStream, _parse_service_with_state, _parse_stream_response
+from .types import (
+    Checkpoint,
+    NetworkPolicy,
+    PolicyRule,
+    ServiceWithState,
+    Session,
+    SpriteConfig,
+    StreamMessage,
+    URLSettings,
+)
+
+if TYPE_CHECKING:
+    from .async_client import AsyncSpritesClient
+    from .async_exec import AsyncCmd
+    from .async_filesystem import AsyncSpriteFilesystem
+    from .control import ControlConnection
+    from .exec import CompletedProcess
+
+
+class AsyncSprite:
+    """A sprite whose I/O methods are native coroutines."""
+
+    def __init__(self, name: str, client: "AsyncSpritesClient"):
+        """Initialize an async sprite handle.
+
+        Args:
+            name: Sprite name.
+            client: Async client that owns the handle.
+        """
+        self.name = name
+        self.client = client
+        self._control_mode_supported = True
+        self.id: Optional[str] = None
+        self.organization_name: Optional[str] = None
+        self.status: Optional[str] = None
+        self.config: Optional[SpriteConfig] = None
+        self.environment: Optional[Dict[str, str]] = None
+        self.created_at: Optional[datetime] = None
+        self.updated_at: Optional[datetime] = None
+        self.bucket_name: Optional[str] = None
+        self.primary_region: Optional[str] = None
+        self.url: Optional[str] = None
+        self.url_settings: Optional[URLSettings] = None
+        self.version: Optional[str] = None
+        self.environment_version: Optional[str] = None
+        self.labels: List[str] = []
+        self.last_running_at: Optional[datetime] = None
+        self.last_warming_at: Optional[datetime] = None
+
+    def _update_from_info(self, info: Dict[str, Any]) -> None:
+        parsed = parse_sprite_info(info)
+        self.id = parsed.id
+        self.organization_name = parsed.organization
+        self.status = parsed.status
+        self.config = parsed.config
+        self.environment = parsed.environment
+        self.created_at = parsed.created_at
+        self.updated_at = parsed.updated_at
+        self.url = parsed.url
+        self.primary_region = parsed.primary_region
+        self.bucket_name = parsed.bucket_name
+        self.url_settings = parsed.url_settings
+        self.version = parsed.version
+        self.environment_version = parsed.environment_version
+        self.labels = parsed.labels
+        self.last_running_at = parsed.last_running_at
+        self.last_warming_at = parsed.last_warming_at
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.client.token}",
+            "Content-Type": "application/json",
+        }
+
+    def _base_url(self) -> str:
+        return sprite_base_url(self.client.base_url, self.name)
+
+    def filesystem(self, working_dir: str = "/") -> "AsyncSpriteFilesystem":
+        """Return an async pathlib-like filesystem interface.
+
+        Args:
+            working_dir: Base directory for relative paths.
+
+        Returns:
+            An async filesystem bound to this sprite.
+        """
+        from .async_filesystem import AsyncSpriteFilesystem
+
+        return AsyncSpriteFilesystem(self, working_dir)
+
+    async def destroy(self) -> None:
+        """Destroy this sprite."""
+        await self.client.destroy_sprite(self.name)
+
+    async def delete(self) -> None:
+        """Alias for :meth:`destroy`."""
+        await self.destroy()
+
+    async def upgrade(self) -> None:
+        """Upgrade this sprite to the latest runtime version."""
+        await self.client.upgrade_sprite(self.name)
+
+    async def update_url_settings(self, settings: URLSettings) -> None:
+        """Update this sprite's URL access settings.
+
+        Args:
+            settings: Replacement URL access settings.
+        """
+        await self.client.update_url_settings(self.name, settings)
+
+    async def update(
+        self,
+        *,
+        url_settings: Optional[URLSettings] = None,
+        labels: Optional[List[str]] = None,
+    ) -> "AsyncSprite":
+        """Partially update mutable settings.
+
+        Args:
+            url_settings: Replacement URL access settings, when supplied.
+            labels: Replacement labels, when supplied.
+
+        Returns:
+            A populated handle containing the updated metadata.
+        """
+        return await self.client.update_sprite(
+            self.name, url_settings=url_settings, labels=labels
+        )
+
+    async def list_sessions(self) -> List[Session]:
+        """List active command sessions.
+
+        Returns:
+            Active sessions reported by the sprite.
+        """
+        try:
+            response = await self.client._client.get(
+                f"{self._base_url()}/exec", headers=self._headers()
+            )
+        except httpx.RequestError as exc:
+            raise NetworkError(f"Network error listing sessions: {exc}") from exc
+        if not response.is_success:
+            raise SpriteError(
+                f"Failed to list sessions (status {response.status_code}): {response.text}"
+            )
+
+        sessions = []
+        for item in response.json().get("sessions", []):
+            created = _parse_time(item.get("created")) or datetime.now()
+            sessions.append(
+                Session(
+                    id=item.get("id", ""),
+                    command=item.get("command", ""),
+                    workdir=item.get("workdir", ""),
+                    created=created,
+                    bytes_per_second=int(item.get("bytes_per_second", 0)),
+                    is_active=item.get("is_active", False),
+                    tty=item.get("tty", False),
+                    last_activity=_parse_time(item.get("last_activity")),
+                )
+            )
+        return sessions
+
+    async def list_checkpoints(
+        self, history_filter: Optional[str] = None
+    ) -> List[Checkpoint]:
+        """List checkpoints.
+
+        Args:
+            history_filter: Optional checkpoint-history filter.
+
+        Returns:
+            Matching checkpoints.
+        """
+        params = {"history": history_filter} if history_filter else None
+        try:
+            response = await self.client._client.get(
+                f"{self._base_url()}/checkpoints",
+                headers=self._headers(),
+                params=params,
+            )
+        except httpx.RequestError as exc:
+            raise NetworkError(f"Network error listing checkpoints: {exc}") from exc
+        if not response.is_success:
+            raise SpriteError(
+                f"Failed to list checkpoints (status {response.status_code}): {response.text}"
+            )
+        return [_checkpoint_from_dict(item) for item in response.json()]
+
+    async def get_checkpoint(self, checkpoint_id: str) -> Checkpoint:
+        """Get checkpoint details.
+
+        Args:
+            checkpoint_id: Checkpoint identifier.
+
+        Returns:
+            The requested checkpoint.
+
+        Raises:
+            NotFoundError: If the checkpoint does not exist.
+        """
+        try:
+            response = await self.client._client.get(
+                f"{self._base_url()}/checkpoints/{quote_path_segment(checkpoint_id)}",
+                headers=self._headers(),
+            )
+        except httpx.RequestError as exc:
+            raise NetworkError(f"Network error getting checkpoint: {exc}") from exc
+        if response.status_code == 404:
+            raise NotFoundError(f"Checkpoint not found: {checkpoint_id}")
+        if not response.is_success:
+            raise SpriteError(
+                f"Failed to get checkpoint (status {response.status_code}): {response.text}"
+            )
+        return _checkpoint_from_dict(response.json())
+
+    async def create_checkpoint(
+        self,
+        comment: str = "",
+        *,
+        timeout: Union[float, httpx.Timeout] = CHECKPOINT_TIMEOUT,
+    ) -> CheckpointStream:
+        """Create a checkpoint and return its progress messages.
+
+        Args:
+            comment: Optional checkpoint comment.
+            timeout: HTTP timeout in seconds or an ``httpx.Timeout``.
+
+        Returns:
+            A finite iterator of checkpoint progress messages.
+        """
+        payload = {"comment": comment} if comment else {}
+        try:
+            response = await self.client._client.post(
+                f"{self._base_url()}/checkpoint",
+                headers=self._headers(),
+                json=payload,
+                timeout=timeout,
+            )
+        except httpx.RequestError as exc:
+            raise APIError(f"Failed to create checkpoint: {exc}") from exc
+        if response.status_code != 200:
+            raise APIError(
+                f"Failed to create checkpoint (status {response.status_code})",
+                status_code=response.status_code,
+                response=response.text,
+            )
+        return _MessageIterator(_parse_messages(response.text))
+
+    async def restore_checkpoint(
+        self,
+        checkpoint_id: str,
+        *,
+        timeout: Union[float, httpx.Timeout] = CHECKPOINT_TIMEOUT,
+    ) -> RestoreStream:
+        """Restore a checkpoint and return its progress messages.
+
+        Args:
+            checkpoint_id: Checkpoint identifier.
+            timeout: HTTP timeout in seconds or an ``httpx.Timeout``.
+
+        Returns:
+            A finite iterator of restore progress messages.
+        """
+        url = (
+            f"{self._base_url()}/checkpoints/"
+            f"{quote_path_segment(checkpoint_id)}/restore"
+        )
+        try:
+            response = await self.client._client.post(
+                url, headers=self._headers(), timeout=timeout
+            )
+        except httpx.RequestError as exc:
+            raise APIError(f"Failed to restore checkpoint: {exc}") from exc
+        if response.status_code != 200:
+            raise APIError(
+                f"Failed to restore checkpoint (status {response.status_code})",
+                status_code=response.status_code,
+                response=response.text,
+            )
+        return _MessageIterator(_parse_messages(response.text))
+
+    def command(
+        self,
+        *args: str,
+        env: Optional[Dict[str, str]] = None,
+        cwd: Optional[str] = None,
+        timeout: Optional[float] = None,
+        stdin: Any = None,
+        stdout: Any = None,
+        stderr: Any = None,
+        tty: bool = False,
+        tty_rows: int = 24,
+        tty_cols: int = 80,
+    ) -> "AsyncCmd":
+        """Create an asynchronously executable command.
+
+        Args:
+            *args: Command and arguments.
+            env: Environment variables.
+            cwd: Working directory.
+            timeout: Maximum execution time in seconds.
+            stdin: Optional binary stdin source.
+            stdout: Optional binary stdout sink.
+            stderr: Optional binary stderr sink.
+            tty: Whether to allocate a pseudo-terminal.
+            tty_rows: Terminal height in rows.
+            tty_cols: Terminal width in columns.
+
+        Returns:
+            A command that can be awaited through ``run`` or ``output``.
+        """
+        from .async_exec import AsyncCmd
+
+        return AsyncCmd(
+            sprite=self,
+            args=list(args),
+            env=env,
+            cwd=cwd,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            tty=tty,
+            tty_rows=tty_rows,
+            tty_cols=tty_cols,
+            timeout=timeout,
+        )
+
+    async def run(
+        self,
+        *args: str,
+        capture_output: bool = False,
+        timeout: Optional[float] = None,
+        check: bool = False,
+        env: Optional[Dict[str, str]] = None,
+        cwd: Optional[str] = None,
+        tty: bool = False,
+        tty_rows: int = 24,
+        tty_cols: int = 80,
+    ) -> "CompletedProcess":
+        """Run a command asynchronously, mirroring ``subprocess.run``.
+
+        Args:
+            *args: Command and arguments.
+            capture_output: Capture stdout and stderr in the result.
+            timeout: Maximum execution time in seconds.
+            check: Raise ``ExitError`` for a non-zero exit status.
+            env: Environment variables.
+            cwd: Working directory.
+            tty: Whether to allocate a pseudo-terminal.
+            tty_rows: Terminal height in rows.
+            tty_cols: Terminal width in columns.
+
+        Returns:
+            Completed command information.
+        """
+        from .async_exec import run
+
+        return await run(
+            self,
+            *args,
+            capture_output=capture_output,
+            timeout=timeout,
+            check=check,
+            env=env,
+            cwd=cwd,
+            tty=tty,
+            tty_rows=tty_rows,
+            tty_cols=tty_cols,
+        )
+
+    def attach_session(
+        self, session_id: str, timeout: Optional[float] = None
+    ) -> "AsyncCmd":
+        """Create a command attached to an existing session.
+
+        Args:
+            session_id: Existing session identifier.
+            timeout: Maximum attachment time in seconds.
+
+        Returns:
+            An asynchronously executable attached command.
+        """
+        from .async_exec import AsyncCmd
+
+        return AsyncCmd(self, [], session_id=session_id, timeout=timeout)
+
+    async def list_services(self) -> List[ServiceWithState]:
+        """List configured services and their current state."""
+        response = await self._service_request(
+            "GET", f"{self._base_url()}/services", "list services"
+        )
+        data = response.json()
+        if isinstance(data, dict):
+            data = data.get("services", [])
+        return [_parse_service_with_state(item) for item in data]
+
+    async def get_service(self, service_name: str) -> ServiceWithState:
+        """Get a service by name.
+
+        Args:
+            service_name: Service name.
+
+        Returns:
+            The service and its current state.
+        """
+        response = await self._service_request(
+            "GET",
+            f"{self._base_url()}/services/{quote_path_segment(service_name)}",
+            "get service",
+        )
+        return _parse_service_with_state(response.json())
+
+    async def delete_service(self, service_name: str) -> None:
+        """Delete a service.
+
+        Args:
+            service_name: Service name.
+        """
+        await self._service_request(
+            "DELETE",
+            f"{self._base_url()}/services/{quote_path_segment(service_name)}",
+            "delete service",
+            valid_statuses=(200, 204),
+        )
+
+    async def create_service(
+        self,
+        service_name: str,
+        cmd: str,
+        args: Optional[List[str]] = None,
+        needs: Optional[List[str]] = None,
+        http_port: Optional[int] = None,
+        duration: Optional[float] = None,
+        *,
+        env: Optional[Dict[str, str]] = None,
+        dir: Optional[str] = None,
+    ) -> ServiceStream:
+        """Create or update a service.
+
+        Args:
+            service_name: Service name.
+            cmd: Executable to run.
+            args: Command arguments.
+            needs: Service dependencies.
+            http_port: HTTP port exposed by the service.
+            duration: Monitoring duration in seconds.
+            env: Environment variables.
+            dir: Working directory.
+
+        Returns:
+            A finite iterator of service events.
+        """
+        url = f"{self._base_url()}/services/{quote_path_segment(service_name)}"
+        if duration:
+            url += f"?duration={duration}s"
+        payload: Dict[str, object] = {"cmd": cmd}
+        if args:
+            payload["args"] = args
+        if needs:
+            payload["needs"] = needs
+        if http_port is not None:
+            payload["http_port"] = http_port
+        if env is not None:
+            payload["env"] = env
+        if dir is not None:
+            payload["dir"] = dir
+        response = await self._service_request(
+            "PUT", url, "create service", json=payload, timeout=120.0
+        )
+        return ServiceStream(_parse_stream_response(response.text))
+
+    async def start_service(
+        self, service_name: str, duration: Optional[float] = None
+    ) -> ServiceStream:
+        """Start a service and return its events.
+
+        Args:
+            service_name: Service name.
+            duration: Monitoring duration in seconds.
+
+        Returns:
+            A finite iterator of service events.
+        """
+        url = f"{self._base_url()}/services/{quote_path_segment(service_name)}/start"
+        if duration:
+            url += f"?duration={duration}s"
+        response = await self._service_request(
+            "POST", url, "start service", timeout=120.0
+        )
+        return ServiceStream(_parse_stream_response(response.text))
+
+    async def stop_service(
+        self, service_name: str, timeout: Optional[float] = None
+    ) -> ServiceStream:
+        """Stop a service and return its events.
+
+        Args:
+            service_name: Service name.
+            timeout: Grace period before force stopping.
+
+        Returns:
+            A finite iterator of service events.
+        """
+        url = f"{self._base_url()}/services/{quote_path_segment(service_name)}/stop"
+        if timeout:
+            url += f"?timeout={timeout}s"
+        response = await self._service_request(
+            "POST", url, "stop service", timeout=120.0
+        )
+        return ServiceStream(_parse_stream_response(response.text))
+
+    async def signal_service(self, service_name: str, signal: str) -> None:
+        """Send a signal to a running service.
+
+        Args:
+            service_name: Service name.
+            signal: Signal name, such as ``SIGTERM``.
+        """
+        await self._service_request(
+            "POST",
+            f"{self._base_url()}/services/signal",
+            "signal service",
+            json={"name": service_name, "signal": signal},
+            valid_statuses=(200, 204),
+        )
+
+    async def _service_request(
+        self,
+        method: str,
+        url: str,
+        operation: str,
+        valid_statuses: tuple[int, ...] = (200,),
+        **kwargs: Any,
+    ) -> httpx.Response:
+        try:
+            response = await self.client._client.request(
+                method, url, headers=self._headers(), **kwargs
+            )
+        except httpx.RequestError as exc:
+            raise APIError(f"Failed to {operation}: {exc}") from exc
+        if response.status_code not in valid_statuses:
+            raise APIError(
+                f"Failed to {operation} (status {response.status_code})",
+                status_code=response.status_code,
+                response=response.text,
+            )
+        return response
+
+    async def get_network_policy(self) -> NetworkPolicy:
+        """Get the sprite's current network policy."""
+        try:
+            response = await self.client._client.get(
+                f"{self._base_url()}/policy/network", headers=self._headers()
+            )
+        except httpx.RequestError as exc:
+            raise NetworkError(f"Network error getting network policy: {exc}") from exc
+        if not response.is_success:
+            raise SpriteError(
+                f"Failed to get network policy (status {response.status_code}): {response.text}"
+            )
+        return NetworkPolicy(
+            rules=[
+                PolicyRule(
+                    domain=item.get("domain"),
+                    action=item.get("action"),
+                    include=item.get("include"),
+                )
+                for item in response.json().get("rules", [])
+            ]
+        )
+
+    async def update_network_policy(self, policy: NetworkPolicy) -> None:
+        """Replace the sprite's network policy.
+
+        Args:
+            policy: Replacement network policy.
+        """
+        rules = [
+            {
+                key: value
+                for key, value in {
+                    "domain": rule.domain,
+                    "action": rule.action,
+                    "include": rule.include,
+                }.items()
+                if value is not None
+            }
+            for rule in policy.rules
+        ]
+        try:
+            response = await self.client._client.post(
+                f"{self._base_url()}/policy/network",
+                headers=self._headers(),
+                json={"rules": rules},
+            )
+        except httpx.RequestError as exc:
+            raise NetworkError(f"Network error updating network policy: {exc}") from exc
+        if not response.is_success:
+            raise SpriteError(
+                f"Failed to update network policy (status {response.status_code}): {response.text}"
+            )
+
+    def use_control_mode(self) -> bool:
+        """Return whether multiplexed control mode is enabled and supported."""
+        return self.client.control_mode and self._control_mode_supported
+
+    async def get_control_connection(self) -> "ControlConnection":
+        """Acquire a multiplexed control connection for this sprite."""
+        from .control import get_control_connection
+
+        return await get_control_connection(self)
+
+    async def close_control_connection(self) -> None:
+        """Close this sprite's control pool on the current event loop."""
+        from .control import close_control_connection
+
+        await close_control_connection(self)
+
+    def has_control_connection(self) -> bool:
+        """Return whether this client and sprite own a control connection."""
+        from .control import has_control_connection
+
+        return has_control_connection(self)
+
+
+def _parse_time(value: Any) -> Optional[datetime]:
+    if value:
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            pass
+    return None
+
+
+def _checkpoint_from_dict(data: Dict[str, Any]) -> Checkpoint:
+    return Checkpoint(
+        id=data.get("id", ""),
+        create_time=_parse_time(data.get("create_time")) or datetime.now(),
+        comment=data.get("comment"),
+        history=data.get("history"),
+    )
+
+
+def _parse_messages(text: str) -> List[StreamMessage]:
+    messages = []
+    for line in text.splitlines():
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        messages.append(
+            StreamMessage(
+                type=data.get("type", ""),
+                data=data.get("data"),
+                error=data.get("error"),
+            )
+        )
+    return messages

--- a/src/sprites/client.py
+++ b/src/sprites/client.py
@@ -32,6 +32,20 @@ if TYPE_CHECKING:
     from .sprite import Sprite
 
 
+def _handle_response(response: httpx.Response, operation: str) -> None:
+    """Raise the SDK exception represented by an HTTP response."""
+    if response.status_code == 401:
+        raise AuthenticationError(f"Authentication failed for {operation}")
+    if response.status_code == 404:
+        raise NotFoundError(f"Resource not found for {operation}")
+    if not response.is_success:
+        try:
+            body = response.text
+        except Exception:
+            body = ""
+        raise SpriteError(f"Failed {operation} (status {response.status_code}): {body}")
+
+
 class SpritesClient:
     """Main client for interacting with the Sprites API."""
 
@@ -85,18 +99,7 @@ class SpritesClient:
 
     def _handle_response(self, response: httpx.Response, operation: str) -> None:
         """Handle HTTP response errors."""
-        if response.status_code == 401:
-            raise AuthenticationError(f"Authentication failed for {operation}")
-        if response.status_code == 404:
-            raise NotFoundError(f"Resource not found for {operation}")
-        if not response.is_success:
-            try:
-                body = response.text
-            except Exception:
-                body = ""
-            raise SpriteError(
-                f"Failed {operation} (status {response.status_code}): {body}"
-            )
+        _handle_response(response, operation)
 
     def _sprite_url(self, name: str) -> str:
         return sprite_base_url(self.base_url, name)

--- a/src/sprites/control.py
+++ b/src/sprites/control.py
@@ -5,17 +5,15 @@ from __future__ import annotations
 import asyncio
 import atexit
 import json
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from websockets.asyncio.client import ClientConnection, connect
 from websockets.exceptions import ConnectionClosed
 from websockets.protocol import State
 
+from sprites._interfaces import ClientLike, SpriteLike
 from sprites._signals import signal_headers
 from sprites._utils import quote_path_segment, websocket_base_url
-
-if TYPE_CHECKING:
-    from .sprite import Sprite
 
 # Control envelope protocol constants (must match server's pkg/wss)
 CONTROL_PREFIX = "control:"
@@ -206,7 +204,7 @@ class OpConn:
 class ControlConnection:
     """Manages a persistent WebSocket connection for multiplexed operations."""
 
-    def __init__(self, sprite: Sprite):
+    def __init__(self, sprite: SpriteLike):
         """Initialize a control connection.
 
         Args:
@@ -447,7 +445,7 @@ POOL_DRAIN_TARGET = 10  # Drain down to this many conns when draining
 class ControlPool:
     """Manages a pool of control connections for concurrent operations."""
 
-    def __init__(self, sprite: Sprite, max_size: int = MAX_POOL_SIZE):
+    def __init__(self, sprite: SpriteLike, max_size: int = MAX_POOL_SIZE):
         """Initialize a control pool.
 
         Args:
@@ -568,9 +566,31 @@ class ControlPool:
         return len(self.conns) > 0
 
 
-# Module-level cache for control pools (one pool per sprite)
-_control_pools: Dict[str, ControlPool] = {}
+# Pools cannot cross event-loop or client boundaries: their WebSocket, tasks,
+# locks, and events all belong to the loop on which they were created.
+ControlPoolKey = tuple[asyncio.AbstractEventLoop, int, str, str]
+_control_pools: Dict[ControlPoolKey, ControlPool] = {}
 _cleanup_registered = False
+
+
+def _prune_closed_loop_pools() -> None:
+    """Drop pools whose owning event loops have already been closed."""
+    closed_keys = [key for key in _control_pools if key[0].is_closed()]
+    for key in closed_keys:
+        # Async resources cannot be awaited after their owning loop is closed.
+        # Removing the pool releases the stale loop, client, and connection
+        # references and prevents them from being reused by another loop.
+        _control_pools.pop(key)
+
+
+def _control_pool_key(sprite: SpriteLike) -> ControlPoolKey:
+    """Return the current-loop pool key for a sprite handle."""
+    return (
+        asyncio.get_running_loop(),
+        id(sprite.client),
+        sprite.client.base_url,
+        sprite.name,
+    )
 
 
 def _register_cleanup_on_exit() -> None:
@@ -582,7 +602,7 @@ def _register_cleanup_on_exit() -> None:
         _cleanup_registered = True
 
 
-async def get_control_connection(sprite: Sprite) -> ControlConnection:
+async def get_control_connection(sprite: SpriteLike) -> ControlConnection:
     """Get a control connection from the pool for a sprite.
 
     Args:
@@ -591,7 +611,8 @@ async def get_control_connection(sprite: Sprite) -> ControlConnection:
     Returns:
         ControlConnection instance (caller must release when done)
     """
-    key = f"{sprite.client.base_url}:{sprite.name}"
+    _prune_closed_loop_pools()
+    key = _control_pool_key(sprite)
 
     # Get or create pool
     if key not in _control_pools:
@@ -602,33 +623,33 @@ async def get_control_connection(sprite: Sprite) -> ControlConnection:
     return await pool.acquire()
 
 
-def release_control_connection(sprite: Sprite, cc: ControlConnection) -> None:
+def release_control_connection(sprite: SpriteLike, cc: ControlConnection) -> None:
     """Release a control connection back to the pool.
 
     Args:
         sprite: The sprite whose pool to release to
         cc: The connection to release
     """
-    key = f"{sprite.client.base_url}:{sprite.name}"
+    key = _control_pool_key(sprite)
 
     if key in _control_pools:
         _control_pools[key].release(cc)
 
 
-async def close_control_connection(sprite: Sprite) -> None:
+async def close_control_connection(sprite: SpriteLike) -> None:
     """Close the control pool for a sprite.
 
     Args:
         sprite: The sprite whose pool to close
     """
-    key = f"{sprite.client.base_url}:{sprite.name}"
+    key = _control_pool_key(sprite)
 
     if key in _control_pools:
         pool = _control_pools.pop(key)
         await pool.close()
 
 
-def has_control_connection(sprite: Sprite) -> bool:
+def has_control_connection(sprite: SpriteLike) -> bool:
     """Check if a sprite has any active control connections.
 
     Args:
@@ -637,16 +658,39 @@ def has_control_connection(sprite: Sprite) -> bool:
     Returns:
         True if the sprite has active control connections
     """
-    key = f"{sprite.client.base_url}:{sprite.name}"
-    if key not in _control_pools:
-        return False
-    return _control_pools[key].has_connections()
+    try:
+        pool = _control_pools.get(_control_pool_key(sprite))
+        return pool is not None and pool.has_connections()
+    except RuntimeError:
+        # This inspection helper may be called outside an event loop. Report a
+        # pool only when it belongs to the same client and sprite.
+        return any(
+            client_id == id(sprite.client)
+            and base_url == sprite.client.base_url
+            and name == sprite.name
+            and pool.has_connections()
+            for (_, client_id, base_url, name), pool in _control_pools.items()
+        )
+
+
+async def close_control_pools(client: ClientLike) -> None:
+    """Close every control pool owned by a client on the current event loop.
+
+    Args:
+        client: Client whose multiplexed control connections should be closed.
+    """
+    loop = asyncio.get_running_loop()
+    keys = [key for key in _control_pools if key[0] is loop and key[1] == id(client)]
+    for key in keys:
+        pool = _control_pools.pop(key)
+        await pool.close()
 
 
 async def _close_all_pools() -> None:
-    """Close all control pools. Called on program exit."""
-    pools = list(_control_pools.values())
-    _control_pools.clear()
+    """Close control pools owned by the current loop during process exit."""
+    loop = asyncio.get_running_loop()
+    keys = [key for key in _control_pools if key[0] is loop]
+    pools = [_control_pools.pop(key) for key in keys]
     for pool in pools:
         try:
             await pool.close()

--- a/src/sprites/exec.py
+++ b/src/sprites/exec.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, BinaryIO, Callable
+from typing import BinaryIO, Callable
 
+from sprites._interfaces import SpriteLike
 from sprites.exceptions import ExitError, TimeoutError
-
-if TYPE_CHECKING:
-    from sprites.sprite import Sprite
 
 
 @dataclass
@@ -22,15 +20,12 @@ class CompletedProcess:
     stderr: bytes | None = None
 
 
-class Cmd:
-    """Represents a command to be run on a sprite.
-
-    This class mirrors Go's exec.Cmd API for compatibility with the SDK patterns.
-    """
+class _CmdBase:
+    """State and async transport shared by sync and async commands."""
 
     def __init__(
         self,
-        sprite: Sprite,
+        sprite: SpriteLike,
         args: list[str],
         *,
         env: dict[str, str] | None = None,
@@ -95,88 +90,6 @@ class Cmd:
         self.tty_rows = rows
         self.tty_cols = cols
 
-    def run(self) -> None:
-        """Start command and wait for completion (like exec.Cmd.Run).
-
-        Raises:
-            ExitError: If the command exits with non-zero status.
-            NetworkError: If the connection closes before an exit status arrives.
-            TimeoutError: If the command times out.
-        """
-        code = self._run_sync()
-        if code != 0:
-            raise ExitError(
-                f"exit status {code}", code, self._stdout_data, self._stderr_data
-            )
-
-    def output(self) -> bytes:
-        """Run command and return stdout (like exec.Cmd.Output).
-
-        Returns:
-            The stdout output from the command.
-
-        Raises:
-            ExitError: If the command exits with non-zero status.
-            NetworkError: If the connection closes before an exit status arrives.
-            TimeoutError: If the command times out.
-            RuntimeError: If stdout is already set.
-        """
-        if self.stdout is not None:
-            raise RuntimeError("stdout already set")
-
-        self._capture_stdout = True
-        code = self._run_sync()
-
-        if code != 0:
-            raise ExitError(
-                f"exit status {code}", code, self._stdout_data, self._stderr_data
-            )
-
-        return self._stdout_data
-
-    def combined_output(self) -> bytes:
-        """Run command and return combined stdout/stderr.
-
-        Returns:
-            The combined stdout and stderr output.
-
-        Raises:
-            ExitError: If the command exits with non-zero status.
-            NetworkError: If the connection closes before an exit status arrives.
-            TimeoutError: If the command times out.
-            RuntimeError: If stdout or stderr is already set.
-        """
-        if self.stdout is not None:
-            raise RuntimeError("stdout already set")
-        if self.stderr is not None:
-            raise RuntimeError("stderr already set")
-
-        self._capture_stdout = True
-        self._capture_stderr = True
-        code = self._run_sync()
-
-        # For combined output, merge stdout and stderr
-        combined = self._stdout_data + self._stderr_data
-
-        if code != 0:
-            raise ExitError(f"exit status {code}", code, combined, b"")
-
-        return combined
-
-    def _run_sync(self) -> int:
-        """Run the command synchronously and return exit code."""
-        if self._started:
-            raise RuntimeError("command already started")
-        self._started = True
-
-        try:
-            # Use the persistent event loop for connection reuse
-            from sprites.loop import run_sync
-
-            return run_sync(self._run_async(), timeout=self.timeout)
-        finally:
-            self._finished = True
-
     async def _run_async(self) -> int:
         """Run the command asynchronously."""
         from sprites.websocket import run_ws_command
@@ -197,8 +110,85 @@ class Cmd:
         return self._exit_code
 
 
+class Cmd(_CmdBase):
+    """Represents a synchronously executed command on a sprite.
+
+    This class mirrors Go's ``exec.Cmd`` API for compatibility with the other
+    Sprites SDKs.
+    """
+
+    def run(self) -> None:
+        """Start the command and wait for completion.
+
+        Raises:
+            ExitError: If the command exits with a non-zero status.
+            NetworkError: If the connection closes before an exit status arrives.
+            TimeoutError: If the command times out.
+        """
+        code = self._run_sync()
+        if code != 0:
+            raise ExitError(
+                f"exit status {code}", code, self._stdout_data, self._stderr_data
+            )
+
+    def output(self) -> bytes:
+        """Run the command and return stdout.
+
+        Returns:
+            Bytes written to stdout.
+
+        Raises:
+            ExitError: If the command exits with a non-zero status.
+            RuntimeError: If stdout is already configured.
+        """
+        if self.stdout is not None:
+            raise RuntimeError("stdout already set")
+        self._capture_stdout = True
+        code = self._run_sync()
+        if code != 0:
+            raise ExitError(
+                f"exit status {code}", code, self._stdout_data, self._stderr_data
+            )
+        return self._stdout_data
+
+    def combined_output(self) -> bytes:
+        """Run the command and return stdout followed by stderr.
+
+        Returns:
+            Combined stdout and stderr bytes.
+
+        Raises:
+            ExitError: If the command exits with a non-zero status.
+            RuntimeError: If stdout or stderr is already configured.
+        """
+        if self.stdout is not None:
+            raise RuntimeError("stdout already set")
+        if self.stderr is not None:
+            raise RuntimeError("stderr already set")
+        self._capture_stdout = True
+        self._capture_stderr = True
+        code = self._run_sync()
+        combined = self._stdout_data + self._stderr_data
+        if code != 0:
+            raise ExitError(f"exit status {code}", code, combined, b"")
+        return combined
+
+    def _run_sync(self) -> int:
+        """Run the command on the SDK's persistent event loop."""
+        if self._started:
+            raise RuntimeError("command already started")
+        self._started = True
+        try:
+            from sprites.loop import run_sync
+
+            self._exit_code = run_sync(self._run_async(), timeout=self.timeout)
+            return self._exit_code
+        finally:
+            self._finished = True
+
+
 def run(
-    sprite: Sprite,
+    sprite: SpriteLike,
     *args: str,
     capture_output: bool = False,
     timeout: float | None = None,

--- a/src/sprites/filesystem.py
+++ b/src/sprites/filesystem.py
@@ -20,10 +20,11 @@ from __future__ import annotations
 
 import posixpath
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Union
+from typing import TYPE_CHECKING, Dict, Iterator, List, Union
 
 import httpx
 
+from ._path import _SpritePathBase
 from ._utils import sprite_base_url
 from .exceptions import (
     DirectoryNotEmptyError,
@@ -39,187 +40,37 @@ if TYPE_CHECKING:
     from .sprite import Sprite
 
 
-class SpritePath:
+def _handle_filesystem_error(
+    response: httpx.Response, operation: str, path: str
+) -> None:
+    """Raise the filesystem exception represented by an HTTP response."""
+    if response.status_code == 404:
+        raise FileNotFoundError_(operation, path)
+
+    try:
+        data = response.json()
+        error_msg = data.get("error", response.text)
+        error_code = data.get("code", "")
+
+        if error_code == "EISDIR" or "is a directory" in error_msg.lower():
+            raise IsADirectoryError_(operation, path)
+        if error_code == "ENOTDIR" or "not a directory" in error_msg.lower():
+            raise NotADirectoryError_(operation, path)
+        if error_code == "EACCES" or "permission denied" in error_msg.lower():
+            raise PermissionError_(operation, path)
+        if error_code == "ENOTEMPTY" or "not empty" in error_msg.lower():
+            raise DirectoryNotEmptyError(operation, path)
+        raise FilesystemError(error_msg, operation, path, error_code)
+    except (ValueError, KeyError):
+        raise FilesystemError(response.text, operation, path) from None
+
+
+class SpritePath(_SpritePathBase["SpritePath", "SpriteFilesystem"]):
     """
     A pathlib.Path-like interface for sprite filesystem operations.
 
     Supports path operations using / operator and standard file methods.
     """
-
-    def __init__(self, filesystem: "SpriteFilesystem", path: str):
-        """
-        Initialize a SpritePath.
-
-        Args:
-            filesystem: Parent SpriteFilesystem instance
-            path: Path relative to the filesystem's working directory
-        """
-        self._fs = filesystem
-        self._path = self._normalize_path(path)
-
-    def _normalize_path(self, path: str) -> str:
-        """Normalize path to absolute POSIX path."""
-        if not path:
-            path = "."
-        # If relative, join with current path
-        if not path.startswith("/"):
-            if self._fs._working_dir == "/":
-                path = "/" + path
-            else:
-                path = posixpath.join(self._fs._working_dir, path)
-        # Normalize .. and . components
-        return posixpath.normpath(path)
-
-    def __truediv__(self, other: Union[str, "SpritePath"]) -> "SpritePath":
-        """Support path / "subpath" syntax."""
-        if isinstance(other, SpritePath):
-            other_path = other._path
-        else:
-            other_path = str(other)
-
-        if other_path.startswith("/"):
-            # Absolute path - use as-is
-            new_path = other_path
-        else:
-            # Relative path - join with current
-            new_path = posixpath.join(self._path, other_path)
-
-        return SpritePath(self._fs, new_path)
-
-    def __rtruediv__(self, other: str) -> "SpritePath":
-        """Support "path" / sprite_path syntax."""
-        return SpritePath(self._fs, posixpath.join(other, self._path))
-
-    def __str__(self) -> str:
-        return self._path
-
-    def __repr__(self) -> str:
-        return f"SpritePath({self._path!r})"
-
-    def __fspath__(self) -> str:
-        return self._path
-
-    def __eq__(self, other: Any) -> bool:
-        if isinstance(other, SpritePath):
-            return self._path == other._path and self._fs is other._fs
-        return False
-
-    def __hash__(self) -> int:
-        return hash(self._path)
-
-    @property
-    def name(self) -> str:
-        """The final component of this path."""
-        return posixpath.basename(self._path)
-
-    @property
-    def stem(self) -> str:
-        """The final component of this path, without its suffix."""
-        name = self.name
-        dot_idx = name.rfind(".")
-        if dot_idx > 0:
-            return name[:dot_idx]
-        return name
-
-    @property
-    def suffix(self) -> str:
-        """The file extension of this path."""
-        name = self.name
-        dot_idx = name.rfind(".")
-        if dot_idx > 0:
-            return name[dot_idx:]
-        return ""
-
-    @property
-    def suffixes(self) -> List[str]:
-        """A list of the path's file extensions."""
-        name = self.name
-        if name.startswith("."):
-            name = name[1:]
-        parts = name.split(".")
-        if len(parts) <= 1:
-            return []
-        return ["." + part for part in parts[1:]]
-
-    @property
-    def parent(self) -> "SpritePath":
-        """The logical parent of this path."""
-        parent_path = posixpath.dirname(self._path)
-        if not parent_path:
-            parent_path = "/"
-        return SpritePath(self._fs, parent_path)
-
-    @property
-    def parents(self) -> List["SpritePath"]:
-        """A sequence of this path's logical parents."""
-        parents = []
-        current = self.parent
-        while current._path != "/" and current._path != self._path:
-            parents.append(current)
-            current = current.parent
-        if current._path == "/":
-            parents.append(current)
-        return parents
-
-    @property
-    def parts(self) -> tuple:
-        """An object providing sequence-like access to the path's components."""
-        if self._path == "/":
-            return ("/",)
-        parts = self._path.split("/")
-        if parts[0] == "":
-            parts[0] = "/"
-        return tuple(p for p in parts if p)
-
-    def is_absolute(self) -> bool:
-        """Return whether this path is absolute."""
-        return self._path.startswith("/")
-
-    def is_relative_to(self, other: Union[str, "SpritePath"]) -> bool:
-        """Return whether this path is relative to another path."""
-        if isinstance(other, SpritePath):
-            other_path = other._path
-        else:
-            other_path = str(other)
-        return (
-            self._path.startswith(other_path.rstrip("/") + "/")
-            or self._path == other_path
-        )
-
-    def joinpath(self, *others: Union[str, "SpritePath"]) -> "SpritePath":
-        """Combine this path with one or more other paths."""
-        result = self
-        for other in others:
-            result = result / other
-        return result
-
-    def with_name(self, name: str) -> "SpritePath":
-        """Return a new path with the name changed."""
-        return self.parent / name
-
-    def with_stem(self, stem: str) -> "SpritePath":
-        """Return a new path with the stem changed."""
-        return self.parent / (stem + self.suffix)
-
-    def with_suffix(self, suffix: str) -> "SpritePath":
-        """Return a new path with the suffix changed."""
-        return self.parent / (self.stem + suffix)
-
-    def relative_to(self, other: Union[str, "SpritePath"]) -> "SpritePath":
-        """Return a relative path from this path to another."""
-        if isinstance(other, SpritePath):
-            other_path = other._path
-        else:
-            other_path = str(other)
-
-        other_path = other_path.rstrip("/")
-        if not self._path.startswith(other_path + "/") and self._path != other_path:
-            raise ValueError(f"{self._path} is not relative to {other_path}")
-
-        rel = self._path[len(other_path) :].lstrip("/")
-        if not rel:
-            rel = "."
-        return SpritePath(self._fs, rel)
 
     # ========== Filesystem Operations ==========
 
@@ -238,26 +89,7 @@ class SpritePath:
 
     def _handle_error(self, response: httpx.Response, operation: str) -> None:
         """Handle HTTP error responses."""
-        if response.status_code == 404:
-            raise FileNotFoundError_(operation, self._path)
-
-        try:
-            data = response.json()
-            error_msg = data.get("error", response.text)
-            error_code = data.get("code", "")
-
-            if error_code == "EISDIR" or "is a directory" in error_msg.lower():
-                raise IsADirectoryError_(operation, self._path)
-            elif error_code == "ENOTDIR" or "not a directory" in error_msg.lower():
-                raise NotADirectoryError_(operation, self._path)
-            elif error_code == "EACCES" or "permission denied" in error_msg.lower():
-                raise PermissionError_(operation, self._path)
-            elif error_code == "ENOTEMPTY" or "not empty" in error_msg.lower():
-                raise DirectoryNotEmptyError(operation, self._path)
-            else:
-                raise FilesystemError(error_msg, operation, self._path, error_code)
-        except (ValueError, KeyError):
-            raise FilesystemError(response.text, operation, self._path)
+        _handle_filesystem_error(response, operation, self._path)
 
     def exists(self) -> bool:
         """Return True if this path exists."""

--- a/src/sprites/websocket.py
+++ b/src/sprites/websocket.py
@@ -16,7 +16,7 @@ from sprites._utils import quote_path_segment, websocket_base_url
 from sprites.exceptions import NetworkError, SpriteError, parse_api_error
 
 if TYPE_CHECKING:
-    from sprites.exec import Cmd
+    from sprites.exec import _CmdBase
 
 
 class StreamID(IntEnum):
@@ -37,7 +37,7 @@ WS_PONG_WAIT = 45  # seconds
 class WSCommand:
     """WebSocket command execution handler."""
 
-    def __init__(self, cmd: Cmd):
+    def __init__(self, cmd: _CmdBase):
         """Initialize a WebSocket command handler.
 
         Args:
@@ -357,7 +357,7 @@ class WSCommand:
         return bytes(self._stderr_buffer)
 
 
-async def run_ws_command(cmd: Cmd) -> int:
+async def run_ws_command(cmd: _CmdBase) -> int:
     """Run a command via WebSocket and return exit code.
 
     Args:
@@ -373,7 +373,7 @@ async def run_ws_command(cmd: Cmd) -> int:
     return await _run_ws_command_direct(cmd)
 
 
-async def _run_ws_command_direct(cmd: Cmd) -> int:
+async def _run_ws_command_direct(cmd: _CmdBase) -> int:
     """Run a command via direct WebSocket (no control mode).
 
     Args:
@@ -408,7 +408,7 @@ async def _run_ws_command_direct(cmd: Cmd) -> int:
                 cmd._stderr_data = ws_cmd.get_stderr()
 
 
-async def run_ws_command_via_control(cmd: Cmd) -> int:
+async def run_ws_command_via_control(cmd: _CmdBase) -> int:
     """Run a command via the control connection for multiplexed operations.
 
     Args:

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+
+import httpx
+import pytest
+
+import sprites.control as control_module
+from sprites import (
+    AsyncCmd,
+    AsyncSprite,
+    AsyncSpriteFilesystem,
+    AsyncSpritePath,
+    AsyncSpritesClient,
+    ListOptions,
+    NetworkPolicy,
+    PolicyRule,
+    Sprite,
+    SpriteFilesystem,
+    SpritePath,
+    SpritesClient,
+    URLSettings,
+)
+from sprites.exceptions import (
+    AuthenticationError,
+    ExitError,
+    NotFoundError,
+    TimeoutError,
+)
+from sprites.exec import Cmd
+
+
+async def make_async_client(handler) -> AsyncSpritesClient:
+    client = AsyncSpritesClient("test-token", base_url="https://api.test")
+    await client._client.aclose()
+    client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return client
+
+
+def public_callables(cls) -> set[str]:
+    return {
+        name
+        for name, value in inspect.getmembers(cls)
+        if not name.startswith("_") and (callable(value) or isinstance(value, property))
+    }
+
+
+@pytest.mark.parametrize(
+    ("async_class", "sync_class", "async_only", "sync_only"),
+    [
+        (AsyncSpritesClient, SpritesClient, {"aclose"}, {"close"}),
+        (AsyncSprite, Sprite, set(), set()),
+        (AsyncSpritePath, SpritePath, set(), set()),
+        (AsyncSpriteFilesystem, SpriteFilesystem, set(), set()),
+        (AsyncCmd, Cmd, set(), set()),
+    ],
+)
+def test_async_public_api_matches_sync_api(
+    async_class, sync_class, async_only: set[str], sync_only: set[str]
+) -> None:
+    assert public_callables(async_class) - async_only == (
+        public_callables(sync_class) - sync_only
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_closes_underlying_client() -> None:
+    async with AsyncSpritesClient("test-token") as client:
+        underlying = client._client
+
+    assert underlying.is_closed
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_only_clients_control_pools(monkeypatch) -> None:
+    class FakePool:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    loop = asyncio.get_running_loop()
+    client = AsyncSpritesClient("test-token")
+    other_client = AsyncSpritesClient("other-token")
+    own_pool = FakePool()
+    other_pool = FakePool()
+    pools = {
+        (loop, id(client), client.base_url, "demo"): own_pool,
+        (loop, id(other_client), other_client.base_url, "demo"): other_pool,
+    }
+    monkeypatch.setattr(control_module, "_control_pools", pools)
+
+    try:
+        await client.aclose()
+
+        assert own_pool.closed is True
+        assert other_pool.closed is False
+        assert list(pools) == [(loop, id(other_client), other_client.base_url, "demo")]
+    finally:
+        await other_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_client_lifecycle_and_pagination() -> None:
+    pages = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal pages
+        if request.method == "POST":
+            assert json.loads(request.content) == {
+                "name": "demo",
+                "labels": ["async"],
+                "url_settings": {"auth": "public"},
+            }
+            return httpx.Response(201, json={"name": "demo", "status": "cold"})
+        if request.method == "DELETE":
+            return httpx.Response(204)
+
+        pages += 1
+        assert request.url.params["prefix"] == "demo"
+        if pages == 1:
+            return httpx.Response(
+                200,
+                json={
+                    "sprites": [{"name": "demo-1"}],
+                    "has_more": True,
+                    "next_continuation_token": "next",
+                },
+            )
+        assert request.url.params["continuation_token"] == "next"
+        return httpx.Response(
+            200, json={"sprites": [{"name": "demo-2"}], "has_more": False}
+        )
+
+    client = await make_async_client(handler)
+    try:
+        sprite = await client.create_sprite(
+            "demo", labels=["async"], url_settings=URLSettings(auth="public")
+        )
+        assert isinstance(sprite, AsyncSprite)
+        assert sprite.status == "cold"
+
+        sprites = await client.list_all_sprites(prefix="demo")
+        assert [item.name for item in sprites] == ["demo-1", "demo-2"]
+        assert all(isinstance(item, AsyncSprite) for item in sprites)
+
+        await client.destroy_sprite("demo")
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_list_sprites_preserves_page_metadata() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["bulk_load"] == "true"
+        return httpx.Response(
+            200,
+            json={
+                "sprites": [{"name": "demo", "labels": ["async"]}],
+                "has_more": False,
+                "running": 1,
+            },
+        )
+
+    client = await make_async_client(handler)
+    try:
+        page = await client.list_sprites(ListOptions(bulk_load=True))
+        assert page.running == 1
+        assert page.sprites[0].labels == ["async"]
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_code", "expected_exception"),
+    [(401, AuthenticationError), (404, NotFoundError)],
+)
+async def test_async_client_maps_api_errors(
+    status_code: int, expected_exception: type[Exception]
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, text="boom")
+
+    client = await make_async_client(handler)
+    try:
+        with pytest.raises(expected_exception):
+            await client.get_sprite("demo")
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_command_runs_on_callers_loop_without_sync_bridge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    running_loop = asyncio.get_running_loop()
+
+    async def run_command(cmd: AsyncCmd) -> int:
+        assert asyncio.get_running_loop() is running_loop
+        cmd._stdout_data = b"hello\n"
+        cmd._exit_code = 0
+        return 0
+
+    def fail_sync_bridge(*args, **kwargs):
+        raise AssertionError("the sync event-loop bridge must not be used")
+
+    monkeypatch.setattr("sprites.websocket.run_ws_command", run_command)
+    monkeypatch.setattr("sprites.loop.run_sync", fail_sync_bridge)
+
+    client = AsyncSpritesClient("test-token")
+    try:
+        cmd = client.sprite("demo").command("echo", "hello")
+        assert isinstance(cmd, AsyncCmd)
+        assert await cmd.output() == b"hello\n"
+        assert cmd.exit_code == 0
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_command_raises_exit_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_command(cmd: AsyncCmd) -> int:
+        cmd._stdout_data = b"partial"
+        cmd._stderr_data = b"failed"
+        return 7
+
+    monkeypatch.setattr("sprites.websocket.run_ws_command", fail_command)
+    client = AsyncSpritesClient("test-token")
+    try:
+        with pytest.raises(ExitError) as exc_info:
+            await client.sprite("demo").command("false").output()
+
+        assert exc_info.value.exit_code() == 7
+        assert exc_info.value.stdout == b"partial"
+        assert exc_info.value.stderr == b"failed"
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_command_timeout_raises_sdk_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def slow_command(cmd: AsyncCmd) -> int:
+        await asyncio.sleep(1)
+        return 0
+
+    monkeypatch.setattr("sprites.websocket.run_ws_command", slow_command)
+    client = AsyncSpritesClient("test-token")
+    try:
+        with pytest.raises(TimeoutError):
+            await client.sprite("demo").command("sleep", timeout=0.01).run()
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_filesystem_uses_async_transport_and_path_types() -> None:
+    seen = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path))
+        if request.url.path.endswith("/fs/write"):
+            assert request.content == b"hello"
+            return httpx.Response(200)
+        if request.url.path.endswith("/fs/read"):
+            return httpx.Response(200, content=b"hello")
+        if request.url.path.endswith("/fs/list"):
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {
+                            "name": "note.txt",
+                            "path": "/app/note.txt",
+                            "isDir": False,
+                        }
+                    ]
+                },
+            )
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    client = await make_async_client(handler)
+    try:
+        fs = client.sprite("demo").filesystem("/app")
+        path = fs / "note.txt"
+        assert isinstance(path, AsyncSpritePath)
+        assert isinstance(path.parent / path.name, AsyncSpritePath)
+
+        await path.write_text("hello")
+        assert await path.read_text() == "hello"
+        assert await path.is_file()
+        entries = [entry async for entry in fs.cwd.iterdir()]
+        assert [entry.name for entry in entries] == ["note.txt"]
+        assert all(isinstance(entry, AsyncSpritePath) for entry in entries)
+    finally:
+        await client.aclose()
+
+    assert ("PUT", "/v1/sprites/demo/fs/write") in seen
+    assert ("GET", "/v1/sprites/demo/fs/read") in seen
+
+
+@pytest.mark.asyncio
+async def test_async_sprite_checkpoint_service_and_policy_operations() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/checkpoints") and request.method == "GET":
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "cp-1",
+                        "create_time": "2026-01-12T21:24:42Z",
+                        "comment": "before",
+                    }
+                ],
+            )
+        if path.endswith("/checkpoint"):
+            return httpx.Response(200, text='{"type":"complete","data":"cp-2"}\n')
+        if path.endswith("/restore"):
+            return httpx.Response(200, text='{"type":"complete"}\n')
+        if path.endswith("/services") and request.method == "GET":
+            return httpx.Response(200, json=[{"name": "web", "cmd": "serve"}])
+        if path.endswith("/services/web") and request.method == "GET":
+            return httpx.Response(200, json={"name": "web", "cmd": "serve"})
+        if path.endswith("/services/web") and request.method == "PUT":
+            assert json.loads(request.content) == {
+                "cmd": "serve",
+                "env": {"MODE": "test"},
+            }
+            return httpx.Response(200, text='{"type":"started"}\n')
+        if path.endswith("/policy/network") and request.method == "GET":
+            return httpx.Response(
+                200, json={"rules": [{"domain": "example.com", "action": "allow"}]}
+            )
+        if path.endswith("/policy/network") and request.method == "POST":
+            assert json.loads(request.content) == {
+                "rules": [{"domain": "example.com", "action": "allow"}]
+            }
+            return httpx.Response(204)
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    client = await make_async_client(handler)
+    sprite = client.sprite("demo")
+    try:
+        checkpoints = await sprite.list_checkpoints()
+        assert checkpoints[0].id == "cp-1"
+
+        checkpoint_events = list(await sprite.create_checkpoint("before"))
+        restore_events = list(await sprite.restore_checkpoint("cp-1"))
+        assert checkpoint_events[0].data == "cp-2"
+        assert restore_events[0].type == "complete"
+
+        services = await sprite.list_services()
+        service = await sprite.get_service("web")
+        service_events = list(
+            await sprite.create_service("web", "serve", env={"MODE": "test"})
+        )
+        assert services[0].name == service.name == "web"
+        assert service_events[0].type == "started"
+
+        policy = await sprite.get_network_policy()
+        assert policy.rules[0].domain == "example.com"
+        await sprite.update_network_policy(
+            NetworkPolicy(rules=[PolicyRule(domain="example.com", action="allow")])
+        )
+    finally:
+        await client.aclose()

--- a/tests/test_loop_cleanup.py
+++ b/tests/test_loop_cleanup.py
@@ -7,16 +7,18 @@ import sprites.control as control_module
 import sprites.loop as loop_module
 
 
-def test_control_cleanup_registers_lazily_on_first_pool(monkeypatch) -> None:
+def test_control_pools_are_scoped_to_their_event_loop(monkeypatch) -> None:
     registered = []
-    connection = object()
+    created = []
 
     class FakePool:
         def __init__(self, sprite) -> None:
             self.sprite = sprite
+            self.connection = object()
+            created.append(self)
 
         async def acquire(self):
-            return connection
+            return self.connection
 
     sprite = SimpleNamespace(
         name="demo",
@@ -30,8 +32,10 @@ def test_control_cleanup_registers_lazily_on_first_pool(monkeypatch) -> None:
     first = asyncio.run(control_module.get_control_connection(sprite))
     second = asyncio.run(control_module.get_control_connection(sprite))
 
-    assert first is connection
-    assert second is connection
+    assert first is not second
+    assert len(created) == 2
+    assert len(control_module._control_pools) == 1
+    assert next(iter(control_module._control_pools))[0].is_closed()
     assert registered == [control_module._cleanup_on_exit]
 
 
@@ -78,12 +82,11 @@ def test_control_cleanup_closes_pools_while_loop_is_running(monkeypatch) -> None
         async def close(self) -> None:
             self.closed = True
 
-    pool = FakePool()
-    pools = {"remaining": pool}
-    monkeypatch.setattr(control_module, "_control_pools", pools)
-
     loop = loop_module.get_loop()
     assert loop.is_running()
+    pool = FakePool()
+    pools = {(loop, 1, "https://api.test", "demo"): pool}
+    monkeypatch.setattr(control_module, "_control_pools", pools)
 
     control_module._cleanup_on_exit()
 

--- a/tests/test_sprite_public_api.py
+++ b/tests/test_sprite_public_api.py
@@ -271,3 +271,22 @@ def test_run_check_raises_exit_error(monkeypatch: pytest.MonkeyPatch) -> None:
         sprite.run("false", check=True)
 
     assert exc_info.value.exit_code() == 2
+
+
+def test_sync_command_records_completed_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def completed_command(cmd: Cmd) -> int:
+        return 7
+
+    monkeypatch.setattr(Cmd, "_run_async", completed_command)
+    client = SpritesClient("test-token", base_url="https://api.test")
+    cmd = client.sprite("demo").command("false")
+
+    try:
+        with pytest.raises(ExitError):
+            cmd.run()
+
+        assert cmd.exit_code == 7
+    finally:
+        client.close()


### PR DESCRIPTION
## Summary

- add AsyncSpritesClient with native async lifecycle, filesystem, command, checkpoint, service, session, and network-policy operations
- share command state and pure path behavior between sync and async implementations
- scope multiplexed control pools by client and event loop, close them from aclose(), and prune closed-loop entries
- preserve and test the completed exit status on synchronous Cmd instances

## User impact

Async applications such as FastAPI services can use sprites-py without blocking their event loop or routing calls through asyncio.to_thread(). Existing synchronous APIs remain available and behavior-compatible, with Cmd.exit_code now correctly reporting the completed status.

Closes #23.

## Verification

- python -m ruff check src tests
- python -m ruff format --check src tests
- python -m mypy src
- python -m pytest -q (118 passed)
- python -m build

## Deployment

No service deployment is required. This is a library-only change and can ship through the normal sprites-py PyPI release process.