### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Chicago"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Chicago"


### PR DESCRIPTION
## Summary
- check Python dependencies weekly
- check GitHub Actions weekly
- run updates Monday mornings in America/Chicago

## User impact
Keeps SDK build and runtime dependencies current through reviewable automated pull requests.

## Deployment
No runtime deployment is required. Dependabot begins using the configuration after this merges to the default branch.